### PR TITLE
✨ Add an optional time-until-reset countdown to the panel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,12 +13,13 @@ the LICENSE, `build.sh`, `tools/`) is repo tooling that stays out of the bundle.
 
 - `src/extension.js` — panel indicator + dropdown UI (ESM, GNOME Shell 45+
   style). The panel shows a Claude icon, a Cairo-drawn usage ring, a percentage,
-  and a tier label; each is independently toggleable via GSettings.
+  an optional time-until-reset countdown, and a tier label; each is
+  independently toggleable via GSettings.
 - `src/prefs.js` — Adwaita preferences (element toggles, panel window, refresh
   interval), bound to GSettings. Also hosts the fallback PKCE sign-in flow,
   shown only when `claudeCodeCredentialsAvailable()` is false.
 - `src/schemas/` — GSettings schema (`org.gnome.shell.extensions.claude-usage`).
-  Keys: `show-icon`/`show-percentage`/`show-tier` (bool),
+  Keys: `show-icon`/`show-percentage`/`show-tier`/`show-reset` (bool),
   `panel-gauge` (`ring`|`bar`|`none`),
   `panel-window` (`five-hour`|`seven-day`|`max`), `poll-seconds` (30-600),
   and the in-app sign-in tokens `access-token`/`refresh-token` (string) +

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ the extension can sign in on its own from the preferences window.
 ## Features
 
 - **Panel indicator** with a Claude icon, a usage gauge (a circular ring or a
-  horizontal bar, your choice, or none), a percentage, and a subscription tier
-  label. Each element can be toggled independently.
+  horizontal bar, your choice, or none), a percentage, an optional time-until-
+  reset countdown, and a subscription tier label. Each element can be toggled
+  independently.
 - **Dropdown** with per-window meters: the 5-hour window, the 7-day window, and
   any per-model 7-day windows the API reports (for example Opus and Sonnet),
   discovered automatically.
@@ -92,10 +93,11 @@ Open the preferences from the dropdown (the gear button) or with:
 gnome-extensions prefs claude-usage@dvdstelt.github.io
 ```
 
-- **Panel elements** - show or hide the icon, percentage, and tier, and choose
-  the usage gauge (circle, bar, or none).
-- **Panel reflects** - which window the ring and percentage track: the 5-hour
-  window, the 7-day window, or whichever is most constrained.
+- **Panel elements** - show or hide the icon, percentage, time until reset, and
+  tier, and choose the usage gauge (circle, bar, or none).
+- **Panel reflects** - which window the ring, percentage, and time-until-reset
+  countdown track: the 5-hour window, the 7-day window, or whichever is most
+  constrained.
 - **Refresh interval** - how often to poll for updated usage (30 to 600
   seconds; default 300).
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -137,6 +137,28 @@ function relativeReset(iso) {
     return `resets in ${days}d ${hrs % 24}h`;
 }
 
+// Compact "time until reset" for the panel: magnitude only, no "resets in"
+// prefix, trimmed to the two largest units. Empty when the timestamp is
+// missing or unparseable so the label collapses instead of showing junk.
+function compactReset(iso) {
+    const target = Date.parse(iso);
+    if (Number.isNaN(target))
+        return '';
+    const diff = target - Date.now();
+    if (diff <= 0)
+        return 'now';
+    if (diff < 60000)
+        return `${Math.floor(diff / 1000)}s`;
+    const mins = Math.round(diff / 60000);
+    if (mins < 60)
+        return `${mins}m`;
+    const hrs = Math.floor(mins / 60);
+    if (hrs < 24)
+        return `${hrs}h${mins % 60}m`;
+    const days = Math.floor(hrs / 24);
+    return `${days}d${hrs % 24}h`;
+}
+
 // A labelled progress meter: title + percentage row, bar, and reset caption.
 class Meter {
     constructor(name) {
@@ -308,11 +330,13 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         this._ring = new Ring();
         this._panelBar = new PanelBar();
         this._panelPct = new St.Label({text: '…', style_class: 'cu-panel-pct', y_align: Clutter.ActorAlign.CENTER});
+        this._panelReset = new St.Label({text: '', style_class: 'cu-panel-reset', y_align: Clutter.ActorAlign.CENTER});
         this._panelTier = new St.Label({text: '', style_class: 'cu-panel-tier', y_align: Clutter.ActorAlign.CENTER});
         box.add_child(this._panelIcon);
         box.add_child(this._ring);
         box.add_child(this._panelBar.root);
         box.add_child(this._panelPct);
+        box.add_child(this._panelReset);
         box.add_child(this._panelTier);
         this.add_child(box);
 
@@ -332,6 +356,7 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
             'changed::panel-gauge', () => this._applyVisibility(),
             'changed::show-percentage', () => this._applyVisibility(),
             'changed::show-tier', () => this._applyVisibility(),
+            'changed::show-reset', () => this._applyVisibility(),
             'changed::panel-window', () => this._renderPanel(),
             'changed::poll-seconds', () => this._startTimer(),
             // Signing in (or out) from prefs changes the token source; refetch.
@@ -365,6 +390,7 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         this._panelBar.root.visible = gauge === 'bar';
         this._panelPct.visible = this._settings.get_boolean('show-percentage');
         this._panelTier.visible = this._settings.get_boolean('show-tier');
+        this._panelReset.visible = this._settings.get_boolean('show-reset');
     }
 
     _buildMenu() {
@@ -667,12 +693,14 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
             this._panelPct.style_class = 'cu-panel-pct';
             this._ring.setUnknown();
             this._panelBar.setUnknown();
+            this._panelReset.text = '';
             return;
         }
         const util = sel.win.utilization;
         const proj = projectedUtil(util, sel.win.resets_at, sel.total);
         this._panelPct.text = `${Math.round(util)}%`;
         this._panelPct.style_class = `cu-panel-pct ${severity(proj)}`;
+        this._panelReset.text = sel.win.resets_at ? compactReset(sel.win.resets_at) : '';
         this._ring.setValue(util, proj);
         this._panelBar.setValue(util, proj);
     }

--- a/src/extension.js
+++ b/src/extension.js
@@ -88,8 +88,10 @@ function exhaustSeconds(util, resetsAtIso, totalSeconds) {
     return toExhaust > 0 && toExhaust < remaining ? toExhaust : null;
 }
 
-// Human-friendly duration: "30s", "45m", "4h 21m", "2d 5h".
-function humanDuration(seconds) {
+// Human-friendly duration trimmed to the two largest units: "30s", "45m",
+// "4h 21m", "2d 5h". sep sets what goes between the two units, e.g. '' for the
+// compact panel form ("4h21m").
+function humanDuration(seconds, sep = ' ') {
     const s = Math.max(0, Math.floor(seconds));
     if (s < 60)
         return `${s}s`;
@@ -98,9 +100,9 @@ function humanDuration(seconds) {
         return `${mins}m`;
     const hrs = Math.floor(mins / 60);
     if (hrs < 24)
-        return `${hrs}h ${mins % 60}m`;
+        return `${hrs}h${sep}${mins % 60}m`;
     const days = Math.floor(hrs / 24);
-    return `${days}d ${hrs % 24}h`;
+    return `${days}d${sep}${hrs % 24}h`;
 }
 
 function tierLabel(subscriptionType, rateLimitTier) {
@@ -138,7 +140,7 @@ function relativeReset(iso) {
 }
 
 // Compact "time until reset" for the panel: magnitude only, no "resets in"
-// prefix, trimmed to the two largest units. Empty when the timestamp is
+// prefix, no separator between units ("4h21m"). Empty when the timestamp is
 // missing or unparseable so the label collapses instead of showing junk.
 function compactReset(iso) {
     const target = Date.parse(iso);
@@ -147,16 +149,7 @@ function compactReset(iso) {
     const diff = target - Date.now();
     if (diff <= 0)
         return 'now';
-    if (diff < 60000)
-        return `${Math.floor(diff / 1000)}s`;
-    const mins = Math.round(diff / 60000);
-    if (mins < 60)
-        return `${mins}m`;
-    const hrs = Math.floor(mins / 60);
-    if (hrs < 24)
-        return `${hrs}h${mins % 60}m`;
-    const days = Math.floor(hrs / 24);
-    return `${days}d${hrs % 24}h`;
+    return humanDuration(diff / 1000, '');
 }
 
 // A labelled progress meter: title + percentage row, bar, and reset caption.
@@ -721,6 +714,7 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         this._panelPct.style_class = 'cu-panel-pct cu-warn';
         this._ring.setUnknown();
         this._panelBar.setUnknown();
+        this._panelReset.text = '';
         let msg;
         if (e instanceof UsageError && e.status === 401)
             msg = 'Session expired. Open Claude Code to sign in again.';
@@ -764,6 +758,7 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         this._sevenDay = null;
         this._panelBar = null;
         this._ring = null;
+        this._panelReset = null;
         this._meterBindings = [];
         this._lastUsage = null;
         this._client = null;

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -63,6 +63,14 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
             settings.bind(key, row, 'active', Gio.SettingsBindFlags.DEFAULT);
         }
 
+        // Time-until-reset for the window chosen by "Panel reflects" below.
+        const resetRow = new Adw.SwitchRow({
+            title: 'Time until reset',
+            subtitle: 'Show the time left before the window selected under "Panel reflects" resets.',
+        });
+        elements.add(resetRow);
+        settings.bind('show-reset', resetRow, 'active', Gio.SettingsBindFlags.DEFAULT);
+
         const gauges = new Gtk.StringList();
         gauges.append('Circle');
         gauges.append('Bar');

--- a/src/schemas/org.gnome.shell.extensions.claude-usage.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.claude-usage.gschema.xml
@@ -27,6 +27,11 @@
       <summary>Show the subscription tier</summary>
       <description>Display the subscription tier label in the panel.</description>
     </key>
+    <key name="show-reset" type="b">
+      <default>false</default>
+      <summary>Show the time until reset</summary>
+      <description>Display, in the panel, the time left before the window selected by panel-window resets.</description>
+    </key>
     <key name="panel-window" type="s">
       <choices>
         <choice value="five-hour"/>

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -30,6 +30,11 @@
 }
 .cu-panel-pct.cu-warn { color: #ffa348; }
 .cu-panel-pct.cu-crit { color: #ff6b6b; }
+.cu-panel-reset {
+    font-size: 9pt;
+    color: rgba(128, 128, 128, 1.0);
+    font-feature-settings: "tnum";
+}
 .cu-panel-tier {
     font-size: 9pt;
     color: rgba(128, 128, 128, 1.0);


### PR DESCRIPTION
## Summary

Adds an optional **time-until-reset countdown** to the panel indicator. A new
*Panel elements ▸ Time until reset* toggle (`show-reset`, default off) shows, next
to the gauge/percentage, how long until the window selected by **Panel reflects**
resets — e.g. `74% 1h28m`.

- New `compactReset()` helper renders a compact magnitude (`45s`, `45m`, `1h28m`,
  `4d3h`, `now`), mirroring the dropdown's `relativeReset()` without the
  "resets in" prefix.
- The label follows the existing `panel-window` selection (five-hour / seven-day /
  most constrained) in lock-step with the ring and percentage.
- Reuses the existing live-countdown timer (`_scheduleCountdown` /
  `_refreshCountdowns` → `_renderPanel`), so it ticks down between polls and counts
  seconds when under 90s out — no extra timer or network traffic.
- Toggleable live like the other panel elements (added to the `changed::`
  visibility handlers); hidden by default.

## Changes

- `src/schemas/org.gnome.shell.extensions.claude-usage.gschema.xml` — new
  `show-reset` boolean key (default `false`).
- `src/extension.js` — `compactReset()`, the `_panelReset` `St.Label` (between the
  percentage and tier), visibility wiring, and the reset text in `_renderPanel()`.
- `src/prefs.js` — "Time until reset" `Adw.SwitchRow` in the Panel elements group.
- `src/stylesheet.css` — `.cu-panel-reset` (dim, tabular figures).
- `README.md`, `AGENTS.md` — docs.

## Validation

Verified end-to-end in a headless GNOME Shell 49 instance reading live usage:

| `Panel reflects` | percentage | time until reset |
| --- | --- | --- |
| five-hour | `74%` | `1h28m` → `1h27m` (ticks down live) |
| seven-day | `31%` | `4d3h` |

The label is shown only when the toggle is on, and switches windows together with
the ring/percentage. Also: `compactReset()` unit-tested (10/10 cases incl.
boundaries), schema compiles, `node --check` clean on both JS files.

## Note on base

This is branched off `main` (1.0.0). The version published on extensions.gnome.org
(1.0.3) appears to carry an unpushed refactor (`lib/oauth.js` extraction,
`gi://Soup?version=3.0` pinning, `connectObject`/explicit-destroy cleanups).
Everything here is additive except the one-line settings-wiring change (adding
`show-reset` to the `changed::` handlers), which may need a trivial re-port onto the
`connectObject` list if you merge onto the newer code.

@dvdstelt for review — thanks!
