### PR TITLE
Show model-scoped weekly windows from the limits array

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,10 +49,8 @@ the LICENSE, `build.sh`, `tools/`) is repo tooling that stays out of the bundle.
 
 - Tier: `~/.claude/.credentials.json` (`claudeAiOauth.subscriptionType` /
   `rateLimitTier`), confirmed via `GET https://api.anthropic.com/api/oauth/profile`.
-- Limits: `GET https://api.anthropic.com/api/oauth/usage` returns `five_hour`,
-  `seven_day`, `seven_day_sonnet` (each `utilization` % + `resets_at`) and
-  `extra_usage`. Required headers: `Authorization: Bearer <token>`,
-  `anthropic-beta: oauth-2025-04-20`, `anthropic-version: 2023-06-01`.
+- Limits: `GET https://api.anthropic.com/api/oauth/usage` returns `five_hour` and `seven_day` (each `utilization` % + `resets_at`), plus `extra_usage`. Required headers: `Authorization: Bearer <token>`, `anthropic-beta: oauth-2025-04-20`, `anthropic-version: 2023-06-01`.
+- Model-scoped weekly windows (the plan's per-model slice, e.g. Fable) now arrive in the `limits` array as entries with `group: "weekly"`, `kind: "weekly_scoped"`, an integer `percent`, and `scope.model.display_name`. The old top-level `seven_day_<model>` keys are still in the payload but null; `scopedWindows()` in `extension.js` reads both shapes and dedupes by label. Run `gjs -m tools/poll.js` to see what the account actually reports.
 - Refresh: `POST https://platform.claude.com/v1/oauth/token` with
   `grant_type=refresh_token` and the public Claude Code `client_id`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.2.0 - 2026-07-10
+
+### Fixed
+- Per-model weekly usage windows (for example Fable) show in the dropdown
+  again. The usage API moved them out of the top-level `seven_day_<model>`
+  fields and into its `limits` array; the extension now reads both shapes and
+  deduplicates by model, so accounts on either payload keep working.
+
+### Changed
+- The "most constrained" panel option now also weighs the model-scoped weekly
+  limits, so approaching a per-model ceiling shows in the panel just like the
+  overall 5-hour and 7-day windows.
+
 ## 1.1.2 - 2026-07-10
 
 ### Changed

--- a/src/extension.js
+++ b/src/extension.js
@@ -189,6 +189,37 @@ function modelLabel(name) {
         name.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
 }
 
+// The scoped weekly windows (a single model getting its own slice of the plan,
+// e.g. Fable) shown alongside the overall 5-hour and 7-day bars.
+//
+// These used to arrive as top-level `seven_day_<name>` keys. Newer payloads
+// report them in the `limits` array as weekly entries carrying a model scope,
+// and leave the old keys present but null, so both shapes have to be read.
+// Returns a Map of stable key -> {label, win}, where `win` is shaped like a
+// usage window (`utilization` + `resets_at`) whatever it was parsed from.
+// Keying on the lowercased label means a model reported through both shapes
+// yields one meter, not two.
+function scopedWindows(usage) {
+    const out = new Map();
+    for (const key of Object.keys(usage)) {
+        const m = /^seven_day_(.+)$/.exec(key);
+        if (!m || !usage[key])
+            continue;
+        const label = modelLabel(m[1]);
+        out.set(label.toLowerCase(), {label, win: usage[key]});
+    }
+    for (const entry of usage.limits ?? []) {
+        const label = entry?.scope?.model?.display_name;
+        if (!label || entry.group !== 'weekly')
+            continue;
+        out.set(label.toLowerCase(), {
+            label,
+            win: {utilization: entry.percent, resets_at: entry.resets_at},
+        });
+    }
+    return out;
+}
+
 function relativeReset(iso) {
     const target = Date.parse(iso);
     if (Number.isNaN(target))
@@ -608,25 +639,20 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         this._bindWindow(this._fiveHour, usage.five_hour, FIVE_HOUR_SECONDS);
         this._bindWindow(this._sevenDay, usage.seven_day, SEVEN_DAY_SECONDS);
 
-        // Per-model 7-day windows arrive as seven_day_<name>; render one meter
-        // per non-null entry and drop any that the API stops reporting.
-        const seen = new Set();
-        for (const key of Object.keys(usage)) {
-            const m = /^seven_day_(.+)$/.exec(key);
-            const win = usage[key];
-            if (!m || !win)
-                continue;
-            seen.add(key);
+        // One meter per model-scoped weekly window, dropping any the API stops
+        // reporting.
+        const scoped = scopedWindows(usage);
+        for (const [key, {label, win}] of scoped) {
             let meter = this._perModelMeters.get(key);
             if (!meter) {
-                meter = new Meter(`7-day ${modelLabel(m[1])}`);
+                meter = new Meter(`7-day ${label}`);
                 this._perModelBox.add_child(meter.root);
                 this._perModelMeters.set(key, meter);
             }
             this._bindWindow(meter, win, SEVEN_DAY_SECONDS);
         }
         for (const [key, meter] of this._perModelMeters) {
-            if (!seen.has(key)) {
+            if (!scoped.has(key)) {
                 meter.destroy();
                 this._perModelMeters.delete(key);
             }
@@ -741,11 +767,18 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         case 'seven-day':
             return {win: u.seven_day, total: SEVEN_DAY_SECONDS};
         case 'max': {
-            const fu = u.five_hour?.utilization ?? -1;
-            const su = u.seven_day?.utilization ?? -1;
-            return su > fu
-                ? {win: u.seven_day, total: SEVEN_DAY_SECONDS}
-                : {win: u.five_hour, total: FIVE_HOUR_SECONDS};
+            // The most constraining window, which includes the model-scoped
+            // weekly ones: hitting the Fable ceiling stops work just as hard as
+            // hitting the overall one.
+            let best = {win: u.five_hour, total: FIVE_HOUR_SECONDS};
+            const consider = (win, total) => {
+                if ((win?.utilization ?? -1) > (best.win?.utilization ?? -1))
+                    best = {win, total};
+            };
+            consider(u.seven_day, SEVEN_DAY_SECONDS);
+            for (const {win} of scopedWindows(u).values())
+                consider(win, SEVEN_DAY_SECONDS);
+            return best;
         }
         case 'five-hour':
         default:

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -8,6 +8,6 @@
   "donations": {
     "paypal": "dvdstelt"
   },
-  "version": 9,
-  "version-name": "1.1.2"
+  "version": 10,
+  "version-name": "1.2.0"
 }

--- a/tools/poll.js
+++ b/tools/poll.js
@@ -19,13 +19,34 @@ async function run() {
 
     const usage = await client.fetchUsage();
     print('\nusage windows:');
-    for (const key of ['five_hour', 'seven_day', 'seven_day_opus', 'seven_day_sonnet']) {
+    for (const key of ['five_hour', 'seven_day']) {
         const w = usage[key];
         if (w)
             print(`  ${key}: ${w.utilization}%  resets ${w.resets_at}`);
         else
             print(`  ${key}: (null)`);
     }
+
+    // Model-scoped weekly windows (e.g. Fable). Legacy payloads put these in
+    // top-level seven_day_<name> keys, newer ones in the `limits` array.
+    print('\nscoped windows:');
+    let scoped = 0;
+    for (const key of Object.keys(usage)) {
+        const m = /^seven_day_(.+)$/.exec(key);
+        if (m && usage[key]) {
+            scoped++;
+            print(`  ${m[1]} (legacy key): ${usage[key].utilization}%  resets ${usage[key].resets_at}`);
+        }
+    }
+    for (const entry of usage.limits ?? []) {
+        const name = entry?.scope?.model?.display_name;
+        if (name && entry.group === 'weekly') {
+            scoped++;
+            print(`  ${name} (limits/${entry.kind}): ${entry.percent}%  resets ${entry.resets_at}`);
+        }
+    }
+    if (!scoped)
+        print('  (none)');
     if (usage.extra_usage)
         print(`  extra_usage: ${usage.extra_usage.used_credits}/${usage.extra_usage.monthly_limit} ${usage.extra_usage.currency}`);
 }


### PR DESCRIPTION
## Summary

The usage endpoint moved per-model weekly windows out of the top-level `seven_day_<model>` keys and into the `limits` array, as weekly entries carrying a `scope.model.display_name` (e.g. Fable). The old keys are still present but `null`, so the popup stopped rendering any per-model bar and the "most constrained" panel option ignored the model ceiling.

## Changes

- New `scopedWindows(usage)` helper reads **both** shapes — the legacy `seven_day_<name>` keys and the new `limits` weekly entries — and deduplicates by model label, so an account on either payload keeps working and a model reported through both yields a single meter.
- The dropdown renders one meter per model-scoped weekly window again, dropping any the API stops reporting.
- The **most constrained** (`max`) panel window now also weighs the model-scoped weekly limits, so approaching a per-model ceiling shows in the panel just like the overall 5-hour and 7-day windows.
- `tools/poll.js` updated to surface the scoped windows for standalone checks.

## Release

- Changelog: new `1.2.0` section (Fixed + Changed).
- `metadata.json` bumped to `1.2.0` / version code `10`.

## Note

The core change is a fix for a broken payload shape; released as `1.2.0` (minor) rather than a patch because it also adapts to the new API structure and extends the "max" behavior.