### PR TITLE
Add support for multiple Claude Code profiles and GNOME Shell updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,25 +12,43 @@ The shipped extension lives in `src/`; everything else (this file, the README,
 the LICENSE, `build.sh`, `tools/`) is repo tooling that stays out of the bundle.
 
 - `src/extension.js` — panel indicator + dropdown UI (ESM, GNOME Shell 45+
-  style). The panel shows a Claude icon, a Cairo-drawn usage ring, a percentage,
-  an optional time-until-reset countdown, and a tier label; each is
-  independently toggleable via GSettings.
+  style). `ProfileView` holds everything specific to one Claude Code profile
+  (its `UsageClient`, panel block, and popup section); `ClaudeUsageIndicator`
+  owns one `ProfileView` per configured profile, plus the shared panel icon,
+  poll timer, and countdown. The panel shows a Claude icon once, then one
+  block per profile (ring/bar, percentage, reset countdown, tier label), each
+  independently toggleable via GSettings (the toggles apply to every profile
+  uniformly). A small chip (e.g. "TE") tags each panel block only when more
+  than one profile is configured.
 - `src/prefs.js` — Adwaita preferences (element toggles, panel window, refresh
-  interval), bound to GSettings. Also hosts the fallback PKCE sign-in flow,
-  shown only when `claudeCodeCredentialsAvailable()` is false.
+  interval, the "Claude profiles" list), bound to GSettings. Also hosts the
+  fallback PKCE sign-in flow, shown only when no configured profile has usable
+  on-disk credentials (`claudeCodeCredentialsAvailable(configDir)` for every
+  profile).
 - `src/schemas/` — GSettings schema (`org.gnome.shell.extensions.claude-usage`).
   Keys: `show-icon`/`show-percentage`/`show-tier`/`show-reset` (bool),
   `panel-gauge` (`ring`|`bar`|`none`),
   `panel-window` (`five-hour`|`seven-day`|`max`), `poll-seconds` (30-600),
-  and the in-app sign-in tokens `access-token`/`refresh-token` (string) +
-  `expires-at` (int64 ms). Recompile after edits:
-  `glib-compile-schemas src/schemas/`.
-- `src/lib/usageClient.js` — pure GI module: resolves a token (Claude Code's
-  on-disk credentials first, the extension's own GSettings tokens second),
-  calls the usage and profile endpoints, refreshes the token when near expiry,
-  and writes it back to whichever store it came from. Exports
-  `claudeCodeCredentialsAvailable()` for prefs. Soup is pinned inline via
-  `gi://Soup?version=3.0` (some systems still ship the 2.4 typelib).
+  `profiles` (JSON string, array of `{id, label, configDir}`),
+  `profiles-initialized` (bool, set once auto-detection has seeded `profiles`
+  so a deliberately-emptied list isn't re-seeded), and the in-app sign-in
+  tokens `access-token`/`refresh-token` (string) + `expires-at` (int64 ms).
+  Recompile after edits: `glib-compile-schemas src/schemas/`.
+- `src/lib/usageClient.js` — pure GI module: resolves a token for a given
+  `configDir` (that profile's on-disk credentials first, the extension's own
+  GSettings tokens second — shared across profiles, since only one in-app
+  sign-in is supported), calls the usage and profile endpoints, refreshes the
+  token when near expiry, and writes it back to whichever store it came from.
+  Exports `claudeCodeCredentialsAvailable(configDir)`, `defaultConfigDir()`
+  (`~/.claude`), and `discoverConfigDirs()` (finds `~/.claude` and sibling
+  `~/.claude-*` directories that already hold credentials). Soup is pinned
+  inline via `gi://Soup?version=3.0` (some systems still ship the 2.4
+  typelib).
+- `src/lib/profiles.js` — the profile list: `loadProfiles`/`saveProfiles`
+  (JSON in the `profiles` GSettings key) and `ensureProfiles` (seeds the list
+  from `discoverConfigDirs()` once, gated by `profiles-initialized`). Kept
+  shell-import-free like `usageClient.js` so prefs and plain `gjs` can use it
+  too.
 - `src/lib/oauth.js` — shared OAuth/API constants (client id, endpoints,
   scopes, headers) and text codecs, imported by both `usageClient.js` and
   `prefs.js` so the values are defined once. No shell imports.
@@ -43,7 +61,8 @@ the LICENSE, `build.sh`, `tools/`) is repo tooling that stays out of the bundle.
   `-patch` flag that bumps `version-name` (semver) in `metadata.json` and
   increments the integer `version` before packing.
 - `tools/poll.js` — standalone validator, run from the repo root:
-  `gjs -m tools/poll.js`.
+  `gjs -m tools/poll.js` (defaults to `~/.claude`) or
+  `gjs -m tools/poll.js ~/.claude-work` to check a specific profile.
 
 ## Data sources
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,10 +36,14 @@ the LICENSE, `build.sh`, `tools/`) is repo tooling that stays out of the bundle.
   Recompile after edits: `glib-compile-schemas src/schemas/`.
 - `src/lib/usageClient.js` — pure GI module: resolves a token for a given
   `configDir` (that profile's on-disk credentials first, the extension's own
-  GSettings tokens second — shared across profiles, since only one in-app
-  sign-in is supported), calls the usage and profile endpoints, refreshes the
+  GSettings tokens second), calls the usage and profile endpoints, refreshes the
   token when near expiry, and writes it back to whichever store it came from.
-  Exports `claudeCodeCredentialsAvailable(configDir)`, `defaultConfigDir()`
+  Only one in-app sign-in is supported, so the `allowSharedToken` option gates
+  the fallback to that token to just the profile it can belong to (the sole
+  profile, or the one owning `~/.claude` — decided in `extension.js`); any other
+  profile without on-disk credentials resolves to a `SignedOutError` that the
+  panel shows as a muted "Signed out" state. Exports
+  `claudeCodeCredentialsAvailable(configDir)`, `defaultConfigDir()`
   (`~/.claude`), and `discoverConfigDirs()` (finds `~/.claude` and sibling
   `~/.claude-*` directories that already hold credentials). Soup is pinned
   inline via `gi://Soup?version=3.0` (some systems still ship the 2.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 1.4.0 - 2026-08-25
+## 1.4.0 - 2026-08-26
+
+Thanks to @rafi0x for the multiple-profile support.
 
 ### Added
 - Support for multiple Claude Code profiles (separate `CLAUDE_CONFIG_DIR`
@@ -16,10 +18,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a single "Refresh all" action. Profiles are auto-detected on first run and
   can be renamed, repointed, added, or removed from a new "Claude profiles"
   group in preferences.
+- A profile whose config directory has no Claude Code login is now shown as
+  signed out, instead of silently displaying another account's usage.
 
 ### Changed
 - GNOME Shell 46 and 47 are now supported (previously 48-50 only), covering
   Ubuntu 24.04 LTS.
+- The account name now appears in each profile's subtitle (for example
+  "Dennis · Claude Code · active"), so it stays visible now that the popup
+  header shows the profile's own label.
+- The subscription pill follows the plan the API reports rather than a fixed
+  list, so team and enterprise seats are labelled correctly.
 
 ## 1.3.0 - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.2.0 - 2026-08-03
+
+### Added
+- Support for multiple Claude Code profiles (separate `CLAUDE_CONFIG_DIR`
+  accounts, e.g. `~/.claude` and `~/.claude-work`). All configured profiles are
+  shown side by side in the panel and the dropdown, and refresh together with
+  a single "Refresh all" action. Profiles are auto-detected on first run and
+  can be renamed, repointed, added, or removed from a new "Claude profiles"
+  group in preferences.
+
+### Changed
+- GNOME Shell 46 and 47 are now supported (previously 48-50 only), covering
+  Ubuntu 24.04 LTS.
+
 ## 1.1.2 - 2026-07-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ preferences window.
   horizontal bar, your choice, or none), a percentage, an optional time-until-
   reset countdown, and a subscription tier label. Each element can be toggled
   independently.
+- **Multiple profiles.** If you run more than one Claude Code account on this
+  machine (via `CLAUDE_CONFIG_DIR`, e.g. `~/.claude` and `~/.claude-work`), the
+  extension shows every configured profile side by side in the panel and the
+  dropdown, and refreshes them all together. Profiles are auto-detected on
+  first run; add, rename, repoint, or remove them from the "Claude profiles"
+  group in preferences.
 - **Dropdown** with per-window meters: the 5-hour window, the 7-day window, and
   any per-model 7-day windows the API reports (for example Opus and Sonnet),
   discovered automatically.
@@ -36,10 +42,11 @@ preferences window.
 
 ## Requirements
 
-- GNOME Shell 48, 49, or 50.
+- GNOME Shell 46, 47, 48, 49, or 50 (Ubuntu 24.04 LTS and newer).
 - Either:
   - **Claude Code** signed in (the extension reads
-    `~/.claude/.credentials.json`), or
+    `~/.claude/.credentials.json`, or another profile directory you configure
+    in preferences), or
   - an in-app sign-in via the preferences window (see Authentication below).
 
 ## Install
@@ -152,7 +159,11 @@ The repository is laid out as:
   - `prefs.js` - Adwaita preferences, including the fallback sign-in flow.
   - `stylesheet.css` - panel and popup styling.
   - `lib/usageClient.js` - token resolution, refresh, and the usage/profile
-    calls.
+    calls, parameterized by config directory so each profile gets its own
+    client.
+  - `lib/profiles.js` - the profile list (label + config directory), stored as
+    JSON in GSettings; auto-detects `~/.claude` and sibling `~/.claude-*`
+    directories on first run.
   - `lib/oauth.js` - shared OAuth/API constants and text codecs used by both
     the usage client and prefs.
   - `schemas/` - GSettings schema. Recompile after edits with

--- a/src/extension.js
+++ b/src/extension.js
@@ -735,20 +735,47 @@ class ProfileView {
         logError(e, `claude-usage: refresh failed for "${this.profile.label}"`);
     }
 
+    // Destroys every widget this view owns, leaf-first, then releases the
+    // references. The children would go with their containers anyway, but the
+    // store's review tooling matches each `this._x = new St.…` against a
+    // corresponding `this._x.destroy()` and cannot infer cascading, so each one
+    // is destroyed explicitly.
     destroy() {
         for (const meter of this._meters.values())
             meter.destroy();
         this._meters.clear();
+
+        // Panel block contents, then the block itself.
+        this._ring?.destroy();
         this._panelBar?.destroy();
         this._chip?.destroy();
+        this._panelPct?.destroy();
+        this._panelReset?.destroy();
+        this._panelTier?.destroy();
         this._panelSep?.destroy();
         this._panelBlock?.destroy();
+
+        // Popup section contents, then the section itself.
+        this._label?.destroy();
+        this._subtitle?.destroy();
+        this._pill?.destroy();
+        this._updated?.destroy();
+        this._metersBox?.destroy();
         this._section?.destroy();
-        this._panelBar = null;
+
         this._ring = null;
+        this._panelBar = null;
+        this._chip = null;
+        this._panelPct = null;
         this._panelReset = null;
+        this._panelTier = null;
         this._panelSep = null;
         this._panelBlock = null;
+        this._label = null;
+        this._subtitle = null;
+        this._pill = null;
+        this._updated = null;
+        this._metersBox = null;
         this._section = null;
         this._meterBindings = [];
         this._windows = [];
@@ -892,7 +919,10 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         });
         const refreshLabel = this._profileViews?.length > 1 ? '↻ Refresh all' : '↻ Refresh';
         this._refreshBtn = new St.Button({label: refreshLabel, style_class: 'cu-refresh', x_expand: true});
-        this._refreshBtn.connect('clicked', () => this._refresh(true));
+        // connectObject so destroy() can drop this with disconnectObject(this);
+        // a bare connect() on a this._* field is flagged by the store's review
+        // tooling as a signal that is never disconnected.
+        this._refreshBtn.connectObject('clicked', () => this._refresh(true), this);
         footer.add_child(settingsBtn);
         footer.add_child(this._refreshBtn);
         root.add_child(footer);
@@ -992,7 +1022,19 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         this._settings.disconnectObject(this);
         this._settings = null;
 
+        this._refreshBtn?.disconnectObject(this);
+        this._refreshBtn?.destroy();
+        this._refreshBtn = null;
+        this._panelIcon?.destroy();
+        this._panelIcon = null;
+
         this._destroyProfileViews();
+
+        // Destroyed after the profile views, which live inside these boxes.
+        this._panelBox?.destroy();
+        this._panelBox = null;
+        this._sectionsBox?.destroy();
+        this._sectionsBox = null;
 
         super.destroy();
     }

--- a/src/extension.js
+++ b/src/extension.js
@@ -531,7 +531,13 @@ class ProfileView {
 
         if (profile?.account) {
             const sub = profile.application?.name ?? 'Claude';
-            this._subtitle.text = profile.organization?.subscription_status === 'active' ? `${sub} · active` : sub;
+            const status = profile.organization?.subscription_status === 'active' ? `${sub} · active` : sub;
+            // The section title is the profile's own label, so fold the account
+            // identity into the subtitle instead of dropping it — otherwise a
+            // single-profile user loses the display name the header used to
+            // show, and it stays useful for telling profiles apart.
+            const who = profile.account.display_name || profile.account.full_name || '';
+            this._subtitle.text = who ? `${who} · ${status}` : status;
             this._pill.text = tierLabel(
                 profile.account.has_claude_max ? 'max' : profile.account.has_claude_pro ? 'pro' : '',
                 profile.organization?.rate_limit_tier);

--- a/src/extension.js
+++ b/src/extension.js
@@ -11,7 +11,7 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
-import {UsageClient, UsageError} from './lib/usageClient.js';
+import {UsageClient, UsageError, SignedOutError, defaultConfigDir} from './lib/usageClient.js';
 import {loadProfiles, ensureProfiles} from './lib/profiles.js';
 import {normalizeWindows, normalizeSpend} from './lib/usageModel.js';
 
@@ -173,10 +173,16 @@ function projectionNote(util, resetsAtIso, totalSeconds) {
     return '';
 }
 
-function tierLabel(subscriptionType, rateLimitTier) {
-    const base = subscriptionType === 'max' ? 'MAX'
-        : subscriptionType === 'pro' ? 'PRO'
-        : (subscriptionType ?? '').toUpperCase() || 'CLAUDE';
+// Plan label for the pill: the API's raw token (`subscriptionType` from disk or
+// `organization_type` from the profile), prefix-stripped and cased — nothing
+// mapped by name, so new plans show through. "CLAUDE" only if the API said
+// nothing. A multiplier in the rate-limit tier ("…_20x") is appended.
+function tierLabel(plan, rateLimitTier) {
+    const base = String(plan ?? '')
+        .replace(/^claude[_-]/i, '')
+        .replace(/[_-]+/g, ' ')
+        .trim()
+        .toUpperCase() || 'CLAUDE';
     const m = /(\d+)x/.exec(rateLimitTier ?? '');
     return m ? `${base} ${m[1]}x` : base;
 }
@@ -410,10 +416,10 @@ class PanelBar {
 // instances are orchestrated by ClaudeUsageIndicator, which shares a single
 // panel icon, poll timer, and countdown across all of them.
 class ProfileView {
-    constructor(profile, settings, panelBox, sectionsBox, showChip, isFirst) {
+    constructor(profile, settings, panelBox, sectionsBox, showChip, isFirst, allowSharedToken) {
         this.profile = profile;
         this._settings = settings;
-        this._client = new UsageClient({configDir: profile.configDir, settings});
+        this._client = new UsageClient({configDir: profile.configDir, settings, allowSharedToken});
         this._lastUsage = null;
         // Normalised windows from the last render, cached for the panel
         // selector and the between-poll countdown.
@@ -463,6 +469,8 @@ class ProfileView {
         who.add_child(this._label);
         who.add_child(this._subtitle);
         this._pill = new St.Label({text: '', style_class: 'cu-pill', y_align: Clutter.ActorAlign.CENTER});
+        // An empty pill still paints as a coloured dot; only show it with a tier.
+        this._pill.visible = false;
         header.add_child(who);
         header.add_child(this._pill);
         this._section.add_child(header);
@@ -499,8 +507,13 @@ class ProfileView {
             const {subscriptionType, rateLimitTier} = await this._client.tierFromDisk();
             if (cancellable.is_cancelled())
                 return;
+            // No credentials on disk: leave the tier blank rather than flash a
+            // generic "CLAUDE"; the refresh fills in the real state shortly.
+            if (!subscriptionType && !rateLimitTier)
+                return;
             const label = tierLabel(subscriptionType, rateLimitTier);
             this._pill.text = label;
+            this._pill.visible = true;
             this._panelTier.text = label.split(' ')[0];
         } catch {
             // Not signed in yet; the refresh will surface a clearer message.
@@ -532,9 +545,13 @@ class ProfileView {
         if (profile?.account) {
             const sub = profile.application?.name ?? 'Claude';
             this._subtitle.text = profile.organization?.subscription_status === 'active' ? `${sub} · active` : sub;
-            this._pill.text = tierLabel(
-                profile.account.has_claude_max ? 'max' : profile.account.has_claude_pro ? 'pro' : '',
-                profile.organization?.rate_limit_tier);
+            // Org plan is authoritative and always present; the has_claude_*
+            // booleans are only a fallback (both false for team/enterprise seats).
+            const plan = profile.organization?.organization_type
+                ?? (profile.account.has_claude_max ? 'max'
+                    : profile.account.has_claude_pro ? 'pro' : null);
+            this._pill.text = tierLabel(plan, profile.organization?.rate_limit_tier);
+            this._pill.visible = true;
             this._panelTier.text = this._pill.text.split(' ')[0];
         }
 
@@ -711,6 +728,11 @@ class ProfileView {
         // profiles are being rebuilt); nothing to show.
         if (e instanceof GLib.Error && e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
             return;
+        // This profile has no login of its own: a state, not a failure.
+        if (e instanceof SignedOutError) {
+            this._renderSignedOut(e);
+            return;
+        }
         // A 429 is transient (we polled a touch too soon). If we already have
         // usage on screen, keep showing it instead of flashing an error.
         if (e instanceof UsageError && e.status === 429 && this._lastUsage) {
@@ -730,9 +752,39 @@ class ProfileView {
         else
             msg = e.message || 'Could not reach Claude';
         this._error.text = msg;
+        this._error.style_class = 'cu-error';
         this._error.visible = true;
         this._updated.text = 'Update failed';
         logError(e, `claude-usage: refresh failed for "${this.profile.label}"`);
+    }
+
+    // Clear any stale usage and show a muted "signed out" line. The account
+    // just needs signing in (via Claude Code, or the in-app sign-in).
+    _renderSignedOut(e) {
+        for (const meter of this._meters.values())
+            meter.destroy();
+        this._meters.clear();
+        this._meterBindings = [];
+        this._windows = [];
+        this._lastUsage = null;
+
+        this._subtitle.text = 'Signed out';
+        this._pill.text = '';
+        this._pill.visible = false;
+        this._panelTier.text = '';
+        this._extra.visible = false;
+
+        this._panelPct.text = '—';
+        this._panelPct.style_class = 'cu-panel-pct';
+        this._ring.setUnknown();
+        this._panelBar.setUnknown();
+        this._panelReset.text = '';
+
+        this._error.text = e.message;
+        this._error.style_class = 'cu-error cu-dim';
+        this._error.visible = true;
+        // Nothing to timestamp; the subtitle and note already say "signed out".
+        this._updated.text = '';
     }
 
     // Destroys every widget this view owns, leaf-first, then releases the
@@ -857,8 +909,15 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
     _buildProfileViews(profiles) {
         this._destroyProfileViews();
         const showChip = profiles.length > 1;
-        this._profileViews = profiles.map((profile, i) =>
-            new ProfileView(profile, this._settings, this._panelBox, this._sectionsBox, showChip, i === 0));
+        // Only the profile the single in-app token can belong to may fall back
+        // to it: the sole profile, or the one owning the default ~/.claude dir.
+        const defaultDir = Gio.File.new_for_path(defaultConfigDir());
+        this._profileViews = profiles.map((profile, i) => {
+            const ownsDefaultDir = Gio.File.new_for_path(profile.configDir).equal(defaultDir);
+            const allowSharedToken = profiles.length === 1 || ownsDefaultDir;
+            return new ProfileView(profile, this._settings, this._panelBox,
+                this._sectionsBox, showChip, i === 0, allowSharedToken);
+        });
         this._applyVisibility();
         for (const view of this._profileViews)
             view.applyTierFromDisk(this._cancellable);

--- a/src/extension.js
+++ b/src/extension.js
@@ -12,6 +12,7 @@ import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
 import {UsageClient, UsageError} from './lib/usageClient.js';
+import {loadProfiles, ensureProfiles} from './lib/profiles.js';
 
 const TRACK_WIDTH = 300;
 const USAGE_SETTINGS_URL = 'https://claude.ai/settings/usage';
@@ -51,9 +52,10 @@ const RING_SIZE = 18;
 const RING_WIDTH = 3;
 const PANEL_BAR_WIDTH = 34;
 
-// StThemeNode colors are Cogl.Color. Across GNOME 48-50 the components come
-// back either as 0-255 bytes or as 0-1 floats depending on the GJS build, so
-// detect the scale instead of assuming one. Returns an [r, g, b] float triple.
+// StThemeNode colors are Cogl.Color. Across GNOME Shell versions the
+// components come back either as 0-255 bytes or as 0-1 floats depending on
+// the GJS build, so detect the scale instead of assuming one. Returns an
+// [r, g, b] float triple.
 function colorRgb(c) {
     const scale = Math.max(c.red, c.green, c.blue) > 1 ? 255 : 1;
     return [c.red / scale, c.green / scale, c.blue / scale];
@@ -187,6 +189,15 @@ function modelLabel(name) {
     const known = {opus: 'Opus', sonnet: 'Sonnet', haiku: 'Haiku', oauth_apps: 'OAuth Apps'};
     return known[name] ??
         name.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+}
+
+// Short (1-2 letter) chip for a profile label, so the panel can distinguish
+// multiple profiles without much width: "TechZu" -> "TE", "My Team" -> "MT".
+function profileChip(label) {
+    const words = (label ?? '').trim().split(/\s+/).filter(Boolean);
+    if (words.length >= 2)
+        return (words[0][0] + words[1][0]).toUpperCase();
+    return (label ?? '').slice(0, 2).toUpperCase() || '?';
 }
 
 function relativeReset(iso) {
@@ -376,88 +387,85 @@ class PanelBar {
     }
 }
 
-const ClaudeUsageIndicator = GObject.registerClass(
-class ClaudeUsageIndicator extends PanelMenu.Button {
-    _init(path, settings, openPreferences) {
-        super._init(0.5, 'Claude Code Usage Monitor');
-
-        this._path = path;
+// Everything specific to one Claude Code profile (one config directory / one
+// account): its own token client, panel block, and popup section. Multiple
+// instances are orchestrated by ClaudeUsageIndicator, which shares a single
+// panel icon, poll timer, and countdown across all of them.
+class ProfileView {
+    constructor(profile, settings, panelBox, sectionsBox, showChip, isFirst) {
+        this.profile = profile;
         this._settings = settings;
-        this._openPreferences = openPreferences;
-        this._client = new UsageClient(settings);
-        this._busy = false;
-        this._cancellable = new Gio.Cancellable();
+        this._client = new UsageClient({configDir: profile.configDir, settings});
         this._lastUsage = null;
-        this._lastFetchMs = 0;
-        this._perModelMeters = new Map();
         this._meterBindings = [];
-        this._countdownTimer = null;
+        this._perModelMeters = new Map();
 
-        // ---- panel button ----
-        const box = new St.BoxLayout({style_class: 'cu-panel'});
-        this._panelIcon = new St.Icon({
-            gicon: Gio.icon_new_for_string(`${path}/icons/claude-spark.svg`),
-            style_class: 'cu-panel-icon',
-            y_align: Clutter.ActorAlign.CENTER,
-        });
+        // ---- panel block ----
+        this._panelBlock = new St.BoxLayout({style_class: 'cu-panel-block'});
+        this._panelSep = null;
+        if (!isFirst) {
+            this._panelSep = new St.Widget({style_class: 'cu-panel-sep', y_align: Clutter.ActorAlign.CENTER});
+            panelBox.add_child(this._panelSep);
+        }
+        if (showChip) {
+            this._chip = new St.Label({
+                text: profileChip(profile.label),
+                style_class: 'cu-panel-chip',
+                y_align: Clutter.ActorAlign.CENTER,
+            });
+            this._panelBlock.add_child(this._chip);
+        }
         this._ring = new Ring();
         this._panelBar = new PanelBar();
         this._panelPct = new St.Label({text: '…', style_class: 'cu-panel-pct', y_align: Clutter.ActorAlign.CENTER});
         this._panelReset = new St.Label({text: '', style_class: 'cu-panel-reset', y_align: Clutter.ActorAlign.CENTER});
         this._panelTier = new St.Label({text: '', style_class: 'cu-panel-tier', y_align: Clutter.ActorAlign.CENTER});
-        box.add_child(this._panelIcon);
-        box.add_child(this._ring);
-        box.add_child(this._panelBar.root);
-        box.add_child(this._panelPct);
-        box.add_child(this._panelReset);
-        box.add_child(this._panelTier);
-        this.add_child(box);
+        this._panelBlock.add_child(this._ring);
+        this._panelBlock.add_child(this._panelBar.root);
+        this._panelBlock.add_child(this._panelPct);
+        this._panelBlock.add_child(this._panelReset);
+        this._panelBlock.add_child(this._panelTier);
+        panelBox.add_child(this._panelBlock);
 
-        this._buildMenu();
-
-        // connectObject ties these handlers to `this`, so a single
-        // disconnectObject(this) in destroy() (and the automatic cleanup when
-        // this actor is destroyed) tears them all down.
-        this.menu.connectObject('open-state-changed', (_m, open) => {
-            if (open)
-                this._refresh();
-        }, this);
-
-        // Live-apply preference changes without needing a shell reload.
-        this._settings.connectObject(
-            'changed::show-icon', () => this._applyVisibility(),
-            'changed::panel-gauge', () => this._applyVisibility(),
-            'changed::show-percentage', () => this._applyVisibility(),
-            'changed::show-tier', () => this._applyVisibility(),
-            'changed::show-reset', () => this._applyVisibility(),
-            'changed::panel-window', () => this._renderPanel(),
-            'changed::poll-seconds', () => this._startTimer(),
-            // Signing in (or out) from prefs changes the token source; refetch.
-            'changed::access-token', () => this._refresh(true),
-            this);
-
-        this._applyVisibility();
-
-        // Tier is on disk, so show it immediately without waiting for the network.
-        this._applyTierFromDisk();
-        this._refresh();
-        this._startTimer();
-    }
-
-    _startTimer() {
-        if (this._timer) {
-            GLib.source_remove(this._timer);
-            this._timer = null;
-        }
-        const seconds = this._settings.get_int('poll-seconds');
-        this._timer = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, seconds, () => {
-            this._refresh();
-            return GLib.SOURCE_CONTINUE;
+        // ---- popup section ----
+        this._section = new St.BoxLayout({
+            vertical: true,
+            style_class: isFirst ? 'cu-profile-section' : 'cu-profile-section cu-profile-section-divider',
         });
+
+        const header = new St.BoxLayout({style_class: 'cu-profile-header'});
+        const who = new St.BoxLayout({vertical: true, x_expand: true});
+        this._label = new St.Label({text: profile.label, style_class: 'cu-title'});
+        this._subtitle = new St.Label({text: '', style_class: 'cu-subtitle'});
+        who.add_child(this._label);
+        who.add_child(this._subtitle);
+        this._pill = new St.Label({text: '', style_class: 'cu-pill', y_align: Clutter.ActorAlign.CENTER});
+        header.add_child(who);
+        header.add_child(this._pill);
+        this._section.add_child(header);
+
+        this._fiveHour = new Meter('5-hour window');
+        this._sevenDay = new Meter('7-day window');
+        this._section.add_child(this._fiveHour.root);
+        this._section.add_child(this._sevenDay.root);
+        // Per-model 7-day meters are added here on demand.
+        this._perModelBox = new St.BoxLayout({vertical: true});
+        this._section.add_child(this._perModelBox);
+
+        this._extra = wrapLabel(new St.Label({text: '', style_class: 'cu-extra'}));
+        this._section.add_child(this._extra);
+
+        this._error = wrapLabel(new St.Label({text: '', style_class: 'cu-error'}));
+        this._error.visible = false;
+        this._section.add_child(this._error);
+
+        this._updated = new St.Label({text: 'Loading…', style_class: 'cu-updated'});
+        this._section.add_child(this._updated);
+
+        sectionsBox.add_child(this._section);
     }
 
-    _applyVisibility() {
-        this._panelIcon.visible = this._settings.get_boolean('show-icon');
+    applyVisibility() {
         const gauge = this._settings.get_string('panel-gauge');
         this._ring.visible = gauge === 'ring';
         this._panelBar.root.visible = gauge === 'bar';
@@ -466,79 +474,7 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         this._panelReset.visible = this._settings.get_boolean('show-reset');
     }
 
-    _buildMenu() {
-        const item = new PopupMenu.PopupBaseMenuItem({reactive: false, can_focus: false});
-        const root = new St.BoxLayout({vertical: true, style_class: 'cu-popup'});
-        item.add_child(root);
-        this.menu.addMenuItem(item);
-
-        // header
-        const header = new St.BoxLayout({style_class: 'cu-header'});
-        const logo = new St.Icon({
-            gicon: Gio.icon_new_for_string(`${this._path}/icons/octopus.png`),
-            style_class: 'cu-logo',
-            y_align: Clutter.ActorAlign.CENTER,
-        });
-        const who = new St.BoxLayout({vertical: true, x_expand: true, y_align: Clutter.ActorAlign.CENTER});
-        this._title = new St.Label({text: 'Claude', style_class: 'cu-title'});
-        this._subtitle = new St.Label({text: 'usage', style_class: 'cu-subtitle'});
-        who.add_child(this._title);
-        who.add_child(this._subtitle);
-        this._pill = new St.Label({text: '', style_class: 'cu-pill', y_align: Clutter.ActorAlign.CENTER});
-        header.add_child(logo);
-        header.add_child(who);
-        header.add_child(this._pill);
-        root.add_child(header);
-
-        // limits section
-        this._sectionLabel(root, 'Usage limits');
-        this._fiveHour = new Meter('5-hour window');
-        this._sevenDay = new Meter('7-day window');
-        root.add_child(this._fiveHour.root);
-        root.add_child(this._sevenDay.root);
-        // Per-model 7-day meters are added here on demand.
-        this._perModelBox = new St.BoxLayout({vertical: true});
-        root.add_child(this._perModelBox);
-
-        this._extra = wrapLabel(new St.Label({text: '', style_class: 'cu-extra'}));
-        root.add_child(this._extra);
-
-        this._error = wrapLabel(new St.Label({text: '', style_class: 'cu-error'}));
-        this._error.visible = false;
-        root.add_child(this._error);
-
-        // actions
-        const actions = new St.BoxLayout({style_class: 'cu-actions'});
-        const openUsage = new St.Button({label: 'Usage page', style_class: 'cu-btn cu-btn-pri', x_expand: true});
-        openUsage.connect('clicked', () => {
-            this.menu.close();
-            Gio.AppInfo.launch_default_for_uri(USAGE_SETTINGS_URL, null);
-        });
-        actions.add_child(openUsage);
-        root.add_child(actions);
-
-        // footer
-        const footer = new St.BoxLayout({style_class: 'cu-footer'});
-        this._updated = new St.Label({text: 'Loading…', style_class: 'cu-updated', x_expand: true});
-        const settings = new St.Button({label: '⚙ Settings', style_class: 'cu-refresh'});
-        settings.connect('clicked', () => {
-            this.menu.close();
-            this._openPreferences?.();
-        });
-        const refresh = new St.Button({label: '↻ Refresh', style_class: 'cu-refresh'});
-        refresh.connect('clicked', () => this._refresh(true));
-        footer.add_child(this._updated);
-        footer.add_child(settings);
-        footer.add_child(refresh);
-        root.add_child(footer);
-    }
-
-    _sectionLabel(parent, text) {
-        parent.add_child(new St.Label({text: text.toUpperCase(), style_class: 'cu-section'}));
-    }
-
-    async _applyTierFromDisk() {
-        const cancellable = this._cancellable;
+    async applyTierFromDisk(cancellable) {
         try {
             const {subscriptionType, rateLimitTier} = await this._client.tierFromDisk();
             if (cancellable.is_cancelled())
@@ -546,46 +482,27 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
             const label = tierLabel(subscriptionType, rateLimitTier);
             this._pill.text = label;
             this._panelTier.text = label.split(' ')[0];
-        } catch (e) {
+        } catch {
             // Not signed in yet; the refresh will surface a clearer message.
         }
     }
 
-    // force bypasses the min-gap throttle (used for explicit user actions like
-    // signing in); opening the popup and the poll timer go through the throttle.
-    _refresh(force = false) {
-        if (this._busy)
-            return;
-        if (!force && Date.now() - this._lastFetchMs < MIN_REFRESH_MS)
-            return;
-        this._busy = true;
-        this._lastFetchMs = Date.now();
-
-        // Capture the cancellable: after teardown it is cancelled (and the
-        // instance reference nulled), which is how we know to drop a late
-        // callback instead of touching destroyed actors.
-        const cancellable = this._cancellable;
-
-        // Usage is required; the profile is cosmetic (name and tier pill), so a
-        // profile failure must not blank out otherwise-good usage data. Run
-        // both in parallel and only surface an error when usage itself fails.
-        Promise.allSettled([
+    // Fetches usage + profile for this account only; never rejects (errors are
+    // reported through renderError). Caller drives concurrency across profiles.
+    async refresh(cancellable) {
+        const [usageRes, profileRes] = await Promise.allSettled([
             this._client.fetchUsage(cancellable),
             this._client.fetchProfile(cancellable),
-        ]).then(([usageRes, profileRes]) => {
-            if (cancellable.is_cancelled())
-                return;
-            if (usageRes.status === 'rejected') {
-                this._renderError(usageRes.reason);
-                return;
-            }
-            if (profileRes.status === 'rejected')
-                logError(profileRes.reason, 'claude-usage: profile fetch failed (non-fatal)');
-            this._render(usageRes.value,
-                profileRes.status === 'fulfilled' ? profileRes.value : null);
-        }).finally(() => {
-            this._busy = false;
-        });
+        ]);
+        if (cancellable.is_cancelled())
+            return;
+        if (usageRes.status === 'rejected') {
+            this._renderError(usageRes.reason);
+            return;
+        }
+        if (profileRes.status === 'rejected')
+            logError(profileRes.reason, `claude-usage: profile fetch failed for "${this.profile.label}" (non-fatal)`);
+        this._render(usageRes.value, profileRes.status === 'fulfilled' ? profileRes.value : null);
     }
 
     _render(usage, profile) {
@@ -593,7 +510,6 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         this._lastUsage = usage;
 
         if (profile?.account) {
-            this._title.text = profile.account.display_name || profile.account.full_name || 'Claude';
             const sub = profile.application?.name ?? 'Claude';
             this._subtitle.text = profile.organization?.subscription_status === 'active' ? `${sub} · active` : sub;
             this._pill.text = tierLabel(
@@ -635,12 +551,6 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         const xu = usage.extra_usage;
         if (xu && xu.is_enabled) {
             const cur = xu.currency || '';
-            // NOTE: the units of used_credits and monthly_limit are not
-            // confirmed against a live extra_usage payload. We scale both the
-            // same way (treating them as minor units, e.g. cents) so the two
-            // numbers are at least consistent; the previous code scaled only
-            // monthly_limit, which could not be right for both. Verify against
-            // real data and adjust the divisor if needed.
             const money = v => Number.isFinite(v) ? `${cur} ${(v / 100).toFixed(2)}`.trim() : null;
             const used = money(Number(xu.used_credits));
             const limit = money(Number(xu.monthly_limit));
@@ -653,8 +563,7 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
             this._extra.visible = false;
         }
 
-        this._renderPanel();
-        this._scheduleCountdown();
+        this.renderPanel();
 
         const now = GLib.DateTime.new_now_local();
         this._updated.text = `Updated ${now.format('%H:%M:%S')}`;
@@ -667,8 +576,8 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         this._applyWindow(meter, win, total);
     }
 
-    // Soonest reset across all on-screen windows, in seconds, or null if none.
-    _soonestResetSeconds() {
+    // Soonest reset among this profile's on-screen windows, in seconds, or null.
+    soonestResetSeconds() {
         let soonest = null;
         for (const {win} of this._meterBindings) {
             if (!win?.resets_at)
@@ -683,32 +592,13 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         return soonest;
     }
 
-    // Tick the "resets in …" captions between polls: every second once a reset
-    // is under 90s away (so the seconds display is live), every 30s otherwise.
-    _scheduleCountdown() {
-        if (this._countdownTimer) {
-            GLib.source_remove(this._countdownTimer);
-            this._countdownTimer = null;
-        }
-        const soonest = this._soonestResetSeconds();
-        if (soonest === null)
-            return;
-        const interval = soonest < 90 ? 1 : 30;
-        this._countdownTimer = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, interval, () => {
-            this._countdownTimer = null;
-            this._refreshCountdowns();
-            this._scheduleCountdown();
-            return GLib.SOURCE_REMOVE;
-        });
-    }
-
     // Re-apply meters and panel from the last fetched usage (captions only move).
-    _refreshCountdowns() {
+    refreshCountdowns() {
         if (!this._lastUsage)
             return;
         for (const {meter, win, total} of this._meterBindings)
             this._applyWindow(meter, win, total);
-        this._renderPanel();
+        this.renderPanel();
     }
 
     // Renders a meter from a usage window. The color reflects the consequence
@@ -753,7 +643,7 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         }
     }
 
-    _renderPanel() {
+    renderPanel() {
         const sel = this._panelWindow();
         if (!sel || !sel.win) {
             this._panelPct.text = '—';
@@ -773,15 +663,14 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
     }
 
     _renderError(e) {
-        // A cancelled request means the extension is being torn down; nothing
-        // to show. (Callers already drop cancelled results, so this is belt
-        // and braces.)
+        // A cancelled request means the extension is being torn down (or
+        // profiles are being rebuilt); nothing to show.
         if (e instanceof GLib.Error && e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
             return;
         // A 429 is transient (we polled a touch too soon). If we already have
         // usage on screen, keep showing it instead of flashing an error.
         if (e instanceof UsageError && e.status === 429 && this._lastUsage) {
-            logError(e, 'claude-usage: rate limited, keeping last data');
+            logError(e, `claude-usage: rate limited for "${this.profile.label}", keeping last data`);
             return;
         }
         this._panelPct.text = '!';
@@ -799,7 +688,250 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         this._error.text = msg;
         this._error.visible = true;
         this._updated.text = 'Update failed';
-        logError(e, 'claude-usage: refresh failed');
+        logError(e, `claude-usage: refresh failed for "${this.profile.label}"`);
+    }
+
+    destroy() {
+        this._fiveHour?.destroy();
+        this._sevenDay?.destroy();
+        for (const meter of this._perModelMeters.values())
+            meter.destroy();
+        this._perModelMeters.clear();
+        this._panelBar?.destroy();
+        this._chip?.destroy();
+        this._panelSep?.destroy();
+        this._panelBlock?.destroy();
+        this._section?.destroy();
+        this._fiveHour = null;
+        this._sevenDay = null;
+        this._panelBar = null;
+        this._ring = null;
+        this._panelReset = null;
+        this._panelSep = null;
+        this._panelBlock = null;
+        this._section = null;
+        this._meterBindings = [];
+        this._lastUsage = null;
+        this._client = null;
+    }
+}
+
+const ClaudeUsageIndicator = GObject.registerClass(
+class ClaudeUsageIndicator extends PanelMenu.Button {
+    _init(path, settings, openPreferences) {
+        super._init(0.5, 'Claude Code Usage Monitor');
+
+        this._path = path;
+        this._settings = settings;
+        this._openPreferences = openPreferences;
+        this._busy = false;
+        this._cancellable = new Gio.Cancellable();
+        this._lastFetchMs = 0;
+        this._profileViews = [];
+        this._countdownTimer = null;
+        this._timer = null;
+
+        // ---- panel button ----
+        this._panelBox = new St.BoxLayout({style_class: 'cu-panel'});
+        this._panelIcon = new St.Icon({
+            gicon: Gio.icon_new_for_string(`${path}/icons/claude-spark.svg`),
+            style_class: 'cu-panel-icon',
+            y_align: Clutter.ActorAlign.CENTER,
+        });
+        this._panelBox.add_child(this._panelIcon);
+        // Profile blocks are appended after the icon by _rebuildProfiles().
+        this.add_child(this._panelBox);
+
+        this._buildMenuShell();
+
+        // connectObject ties these handlers to `this`, so a single
+        // disconnectObject(this) in destroy() (and the automatic cleanup when
+        // this actor is destroyed) tears them all down.
+        this.menu.connectObject('open-state-changed', (_m, open) => {
+            if (open)
+                this._refresh();
+        }, this);
+
+        // Live-apply preference changes without needing a shell reload.
+        this._settings.connectObject(
+            'changed::show-icon', () => this._applyVisibility(),
+            'changed::panel-gauge', () => this._applyVisibility(),
+            'changed::show-percentage', () => this._applyVisibility(),
+            'changed::show-tier', () => this._applyVisibility(),
+            'changed::show-reset', () => this._applyVisibility(),
+            'changed::panel-window', () => this._renderAllPanels(),
+            'changed::poll-seconds', () => this._startTimer(),
+            // Signing in (or out) from prefs changes the token source; refetch.
+            'changed::access-token', () => this._refresh(true),
+            // Profiles were added/removed/renamed/repointed in prefs.
+            'changed::profiles', () => this._rebuildFromSettings(),
+            this);
+
+        this._applyVisibility();
+        this._initProfiles();
+    }
+
+    // One-time async setup: seeds the profile list (auto-detection) if it's
+    // empty, then builds the views. Later profile edits go through
+    // _rebuildFromSettings() instead, which is synchronous and cheap.
+    async _initProfiles() {
+        const cancellable = this._cancellable;
+        const profiles = await ensureProfiles(this._settings);
+        if (cancellable.is_cancelled())
+            return;
+        this._buildProfileViews(profiles);
+    }
+
+    _rebuildFromSettings() {
+        this._buildProfileViews(loadProfiles(this._settings));
+    }
+
+    _buildProfileViews(profiles) {
+        this._destroyProfileViews();
+        const showChip = profiles.length > 1;
+        this._profileViews = profiles.map((profile, i) =>
+            new ProfileView(profile, this._settings, this._panelBox, this._sectionsBox, showChip, i === 0));
+        this._applyVisibility();
+        for (const view of this._profileViews)
+            view.applyTierFromDisk(this._cancellable);
+        this._refresh(true);
+        this._startTimer();
+    }
+
+    _destroyProfileViews() {
+        if (this._countdownTimer) {
+            GLib.source_remove(this._countdownTimer);
+            this._countdownTimer = null;
+        }
+        for (const view of this._profileViews)
+            view.destroy();
+        this._profileViews = [];
+    }
+
+    _buildMenuShell() {
+        const item = new PopupMenu.PopupBaseMenuItem({reactive: false, can_focus: false});
+        const root = new St.BoxLayout({vertical: true, style_class: 'cu-popup'});
+        item.add_child(root);
+        this.menu.addMenuItem(item);
+
+        // header (static branding; per-profile identity lives in each section)
+        const header = new St.BoxLayout({style_class: 'cu-header'});
+        const logo = new St.Icon({
+            gicon: Gio.icon_new_for_string(`${this._path}/icons/octopus.png`),
+            style_class: 'cu-logo',
+            y_align: Clutter.ActorAlign.CENTER,
+        });
+        const who = new St.BoxLayout({vertical: true, x_expand: true, y_align: Clutter.ActorAlign.CENTER});
+        who.add_child(new St.Label({text: 'Claude', style_class: 'cu-title'}));
+        who.add_child(new St.Label({text: 'usage', style_class: 'cu-subtitle'}));
+        header.add_child(logo);
+        header.add_child(who);
+        root.add_child(header);
+
+        // One section per profile, rebuilt whenever the profile list changes.
+        this._sectionsBox = new St.BoxLayout({vertical: true});
+        root.add_child(this._sectionsBox);
+
+        // actions
+        const actions = new St.BoxLayout({style_class: 'cu-actions'});
+        const openUsage = new St.Button({label: 'Usage page', style_class: 'cu-btn cu-btn-pri', x_expand: true});
+        openUsage.connect('clicked', () => {
+            this.menu.close();
+            Gio.AppInfo.launch_default_for_uri(USAGE_SETTINGS_URL, null);
+        });
+        actions.add_child(openUsage);
+        root.add_child(actions);
+
+        // footer
+        const footer = new St.BoxLayout({style_class: 'cu-footer'});
+        const settingsBtn = new St.Button({label: '⚙ Settings', style_class: 'cu-refresh', x_expand: true});
+        settingsBtn.connect('clicked', () => {
+            this.menu.close();
+            this._openPreferences?.();
+        });
+        const refreshLabel = this._profileViews?.length > 1 ? '↻ Refresh all' : '↻ Refresh';
+        this._refreshBtn = new St.Button({label: refreshLabel, style_class: 'cu-refresh', x_expand: true});
+        this._refreshBtn.connect('clicked', () => this._refresh(true));
+        footer.add_child(settingsBtn);
+        footer.add_child(this._refreshBtn);
+        root.add_child(footer);
+    }
+
+    _startTimer() {
+        if (this._timer) {
+            GLib.source_remove(this._timer);
+            this._timer = null;
+        }
+        const seconds = this._settings.get_int('poll-seconds');
+        this._timer = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, seconds, () => {
+            this._refresh();
+            return GLib.SOURCE_CONTINUE;
+        });
+    }
+
+    _applyVisibility() {
+        this._panelIcon.visible = this._settings.get_boolean('show-icon');
+        for (const view of this._profileViews)
+            view.applyVisibility();
+        if (this._refreshBtn)
+            this._refreshBtn.label = this._profileViews.length > 1 ? '↻ Refresh all' : '↻ Refresh';
+    }
+
+    _renderAllPanels() {
+        for (const view of this._profileViews)
+            view.renderPanel();
+    }
+
+    // force bypasses the min-gap throttle (used for explicit user actions like
+    // signing in or editing profiles); opening the popup and the poll timer go
+    // through the throttle. All profiles are fetched concurrently, which is
+    // both faster and simpler than the user refreshing each one by hand.
+    _refresh(force = false) {
+        if (this._busy || this._profileViews.length === 0)
+            return;
+        if (!force && Date.now() - this._lastFetchMs < MIN_REFRESH_MS)
+            return;
+        this._busy = true;
+        this._lastFetchMs = Date.now();
+
+        const cancellable = this._cancellable;
+        Promise.allSettled(this._profileViews.map(view => view.refresh(cancellable)))
+            .finally(() => {
+                this._busy = false;
+                if (!cancellable.is_cancelled())
+                    this._scheduleCountdown();
+            });
+    }
+
+    // Soonest reset across every window of every profile, in seconds, or null.
+    _soonestResetSeconds() {
+        let soonest = null;
+        for (const view of this._profileViews) {
+            const rem = view.soonestResetSeconds();
+            if (rem !== null && (soonest === null || rem < soonest))
+                soonest = rem;
+        }
+        return soonest;
+    }
+
+    // Tick the "resets in …" captions between polls: every second once a reset
+    // is under 90s away (so the seconds display is live), every 30s otherwise.
+    _scheduleCountdown() {
+        if (this._countdownTimer) {
+            GLib.source_remove(this._countdownTimer);
+            this._countdownTimer = null;
+        }
+        const soonest = this._soonestResetSeconds();
+        if (soonest === null)
+            return;
+        const interval = soonest < 90 ? 1 : 30;
+        this._countdownTimer = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, interval, () => {
+            this._countdownTimer = null;
+            for (const view of this._profileViews)
+                view.refreshCountdowns();
+            this._scheduleCountdown();
+            return GLib.SOURCE_REMOVE;
+        });
     }
 
     destroy() {
@@ -819,23 +951,7 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         this._settings.disconnectObject(this);
         this._settings = null;
 
-        // Tear down the gauge/meter helpers and release their references; the
-        // actors themselves also go with super.destroy(), but releasing here
-        // keeps ownership explicit.
-        this._fiveHour?.destroy();
-        this._sevenDay?.destroy();
-        for (const meter of this._perModelMeters.values())
-            meter.destroy();
-        this._perModelMeters.clear();
-        this._panelBar?.destroy();
-        this._fiveHour = null;
-        this._sevenDay = null;
-        this._panelBar = null;
-        this._ring = null;
-        this._panelReset = null;
-        this._meterBindings = [];
-        this._lastUsage = null;
-        this._client = null;
+        this._destroyProfileViews();
 
         super.destroy();
     }

--- a/src/lib/profiles.js
+++ b/src/lib/profiles.js
@@ -1,0 +1,66 @@
+// Profile list management: each profile is {id, label, configDir}, persisted
+// as a JSON string in the "profiles" GSettings key (an array of small objects
+// doesn't map cleanly onto a GVariant type, so JSON keeps this file and prefs
+// simple). Kept free of `resource:///org/gnome/shell` imports so it stays
+// usable from prefs and plain gjs, like usageClient.js.
+import Gio from 'gi://Gio';
+import {discoverConfigDirs, defaultConfigDir} from './usageClient.js';
+
+export function loadProfiles(settings) {
+    let list;
+    try {
+        list = JSON.parse(settings.get_string('profiles'));
+    } catch {
+        list = [];
+    }
+    return Array.isArray(list)
+        ? list.filter(p => p && typeof p.configDir === 'string' && p.configDir)
+        : [];
+}
+
+export function saveProfiles(settings, profiles) {
+    settings.set_string('profiles', JSON.stringify(profiles));
+}
+
+// ".claude" -> "Claude", ".claude-work" -> "Work", ".claude-my-team" -> "My Team".
+export function labelForDirName(name) {
+    if (name === '.claude')
+        return 'Claude';
+    const rest = name.replace(/^\.claude-/, '');
+    const words = rest.split(/[-_]+/).filter(Boolean).map(w => w.charAt(0).toUpperCase() + w.slice(1));
+    return words.length > 0 ? words.join(' ') : 'Claude';
+}
+
+let seq = 0;
+export function makeProfileId() {
+    seq += 1;
+    return `p${Date.now().toString(36)}${seq.toString(36)}`;
+}
+
+// Ensures at least one profile is configured, auto-detecting ~/.claude and any
+// sibling ~/.claude-* directory that already holds Claude Code credentials
+// (that's the standard CLAUDE_CONFIG_DIR convention for running multiple
+// accounts). Runs once: once any profile is saved, later calls are a no-op, so
+// a user who deletes down to zero profiles on purpose isn't re-seeded from
+// under them by the next `enable()`.
+export async function ensureProfiles(settings) {
+    const existing = loadProfiles(settings);
+    if (existing.length > 0)
+        return existing;
+    if (settings.get_boolean('profiles-initialized'))
+        return existing;
+
+    const discovered = await discoverConfigDirs();
+    const seeded = discovered.length > 0
+        ? discovered.map(({name, configDir}) => ({id: makeProfileId(), label: labelForDirName(name), configDir}))
+        : [{id: makeProfileId(), label: 'Claude', configDir: defaultConfigDir()}];
+
+    saveProfiles(settings, seeded);
+    settings.set_boolean('profiles-initialized', true);
+    // This is a one-time write that matters (it's what stops re-seeding from
+    // clobbering a deliberately-emptied list), and prefs is a short-lived
+    // process that may exit right after the window closes; force it to disk
+    // instead of trusting the backend's normal async flush.
+    Gio.Settings.sync();
+    return seeded;
+}

--- a/src/lib/usageClient.js
+++ b/src/lib/usageClient.js
@@ -132,14 +132,29 @@ export class UsageError extends Error {
     }
 }
 
+// A profile has no usable credentials of its own and isn't allowed to borrow
+// the shared in-app token. The caller renders a "signed out" state, not an error.
+export class SignedOutError extends UsageError {
+    constructor(message = 'Not signed in for this profile.') {
+        super(message);
+        this.name = 'SignedOutError';
+        this.signedOut = true;
+    }
+}
+
 export class UsageClient {
     // configDir is the Claude Code config directory to read/write credentials
     // in (defaults to ~/.claude). settings is optional; when provided it
     // supplies the extension's own OAuth tokens (from the in-app sign-in) as a
     // fallback for profiles without usable on-disk credentials.
-    constructor({configDir = defaultConfigDir(), settings = null} = {}) {
+    //
+    // allowSharedToken gates that fallback: the in-app token is a single shared
+    // credential, so only the profile it can belong to may use it (see the
+    // caller). Other profiles resolve to a SignedOutError instead.
+    constructor({configDir = defaultConfigDir(), settings = null, allowSharedToken = true} = {}) {
         this._configDir = configDir;
         this._settings = settings;
+        this._allowSharedToken = allowSharedToken;
         this._session = new Soup.Session();
         this._session.timeout = 15;
         // Shared in-flight token resolution; see _validToken().
@@ -296,14 +311,16 @@ export class UsageClient {
             } catch (e) {
                 // Claude Code's credentials are dead (e.g. its refresh token
                 // expired, which happens when the CLI is unused and only Claude
-                // Desktop is signed in). Fall back to the extension's own in-app
-                // token if the user has signed in; otherwise surface the error.
-                if (this._settings?.get_string('access-token'))
+                // Desktop is signed in). Fall back to the in-app token only if
+                // this profile may use it; otherwise surface the error.
+                if (this._allowSharedToken && this._settings?.get_string('access-token'))
                     return this._settingsToken();
                 throw e;
             }
         }
-        return this._settingsToken();
+        if (this._allowSharedToken)
+            return this._settingsToken();
+        throw new SignedOutError('No Claude Code login found in this profile’s directory.');
     }
 
     async fetchUsage(cancellable = null) {

--- a/src/lib/usageClient.js
+++ b/src/lib/usageClient.js
@@ -14,17 +14,79 @@ import {
 // Refresh when the token expires within this many milliseconds.
 const REFRESH_SKEW_MS = 5 * 60 * 1000;
 
-function credentialsPath() {
-    return GLib.build_filenamev([GLib.get_home_dir(), '.claude', '.credentials.json']);
+// Default Claude Code config directory, used when a profile does not specify
+// its own (keeps single-profile setups working unchanged).
+export function defaultConfigDir() {
+    return GLib.build_filenamev([GLib.get_home_dir(), '.claude']);
+}
+
+function credentialsPath(configDir) {
+    return GLib.build_filenamev([configDir, '.credentials.json']);
+}
+
+// Looks for ~/.claude and any sibling ~/.claude-* directory that holds a
+// .credentials.json, for seeding the profile list on first run. Each Claude
+// Code profile is just a config directory selected via CLAUDE_CONFIG_DIR; this
+// mirrors that convention instead of inventing a new one. Never rejects.
+export async function discoverConfigDirs() {
+    const home = GLib.get_home_dir();
+    const found = [];
+    try {
+        const dir = Gio.File.new_for_path(home);
+        const enumerator = await new Promise((resolve, reject) => {
+            dir.enumerate_children_async(
+                'standard::name,standard::type', Gio.FileQueryInfoFlags.NONE,
+                GLib.PRIORITY_DEFAULT, null, (f, res) => {
+                    try {
+                        resolve(f.enumerate_children_finish(res));
+                    } catch (e) {
+                        reject(e);
+                    }
+                });
+        });
+        // next_files_async/finish (a batch of GFileInfo per round-trip) rather
+        // than the synchronous next_file(), which would block the main loop
+        // once per directory entry.
+        for (;;) {
+            const infos = await new Promise((resolve, reject) => {
+                enumerator.next_files_async(64, GLib.PRIORITY_DEFAULT, null, (e, res) => {
+                    try {
+                        resolve(e.next_files_finish(res));
+                    } catch (err) {
+                        reject(err);
+                    }
+                });
+            });
+            if (infos.length === 0)
+                break;
+            for (const info of infos) {
+                const name = info.get_name();
+                if (name !== '.claude' && !/^\.claude-/.test(name))
+                    continue;
+                if (info.get_file_type() !== Gio.FileType.DIRECTORY)
+                    continue;
+                const configDir = GLib.build_filenamev([home, name]);
+                if (await readCredentialsRoot(configDir))
+                    found.push({name, configDir});
+            }
+        }
+        enumerator.close_async(GLib.PRIORITY_DEFAULT, null, () => {});
+    } catch {
+        // Home directory unreadable for some reason; caller falls back to a
+        // single default profile.
+    }
+    // Stable order: the plain ~/.claude profile first, then alphabetically.
+    found.sort((a, b) => (a.name === '.claude' ? -1 : b.name === '.claude' ? 1 : a.name.localeCompare(b.name)));
+    return found;
 }
 
 // Reads and parses Claude Code's credentials file asynchronously (shell code
 // must avoid synchronous file IO). Resolves to the parsed root object when it
 // holds an access token, or null otherwise. Never rejects: a missing file or
 // bad JSON resolves to null.
-async function readCredentialsRoot() {
+async function readCredentialsRoot(configDir) {
     try {
-        const file = Gio.File.new_for_path(credentialsPath());
+        const file = Gio.File.new_for_path(credentialsPath(configDir));
         const bytes = await new Promise((resolve, reject) => {
             file.load_contents_async(null, (f, res) => {
                 try {
@@ -53,8 +115,8 @@ async function readCredentialsRoot() {
 // e.g. for someone who only uses Claude Desktop), so we surface the in-app
 // sign-in as a fallback. An active CLI user keeps a non-expired access token,
 // so the sign-in stays hidden for them.
-export async function claudeCodeCredentialsAvailable() {
-    const root = await readCredentialsRoot();
+export async function claudeCodeCredentialsAvailable(configDir = defaultConfigDir()) {
+    const root = await readCredentialsRoot(configDir);
     if (!root)
         return false;
     const expiresAt = Number(root.claudeAiOauth.expiresAt) || 0;
@@ -71,10 +133,12 @@ export class UsageError extends Error {
 }
 
 export class UsageClient {
-    // settings is optional; when provided it supplies the extension's own
-    // OAuth tokens (from the in-app sign-in) as a fallback for users without
-    // Claude Code installed.
-    constructor(settings = null) {
+    // configDir is the Claude Code config directory to read/write credentials
+    // in (defaults to ~/.claude). settings is optional; when provided it
+    // supplies the extension's own OAuth tokens (from the in-app sign-in) as a
+    // fallback for profiles without usable on-disk credentials.
+    constructor({configDir = defaultConfigDir(), settings = null} = {}) {
+        this._configDir = configDir;
         this._settings = settings;
         this._session = new Soup.Session();
         this._session.timeout = 15;
@@ -85,7 +149,7 @@ export class UsageClient {
     // Writes Claude Code's credentials back asynchronously (no synchronous file
     // IO on the shell main loop).
     _writeCredentials(root) {
-        const file = Gio.File.new_for_path(credentialsPath());
+        const file = Gio.File.new_for_path(credentialsPath(this._configDir));
         const data = encoder.encode(JSON.stringify(root, null, 2));
         return new Promise((resolve, reject) => {
             // PRIVATE keeps the file at 0600 so the token stays owner-only.
@@ -221,7 +285,7 @@ export class UsageClient {
     }
 
     async _resolveToken() {
-        const root = await readCredentialsRoot();
+        const root = await readCredentialsRoot(this._configDir);
         if (root) {
             const oauth = root.claudeAiOauth;
             const expiresAt = Number(oauth.expiresAt) || 0;
@@ -256,7 +320,7 @@ export class UsageClient {
     // Returns nulls when Claude Code is not signed in (the in-app token path
     // has no tier on disk; it arrives with the profile fetch instead).
     async tierFromDisk() {
-        const oauth = (await readCredentialsRoot())?.claudeAiOauth;
+        const oauth = (await readCredentialsRoot(this._configDir))?.claudeAiOauth;
         return {
             subscriptionType: oauth?.subscriptionType ?? null,
             rateLimitTier: oauth?.rateLimitTier ?? null,

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -8,6 +8,6 @@
   "donations": {
     "paypal": "dvdstelt"
   },
-  "version": 11,
+  "version": 12,
   "version-name": "1.4.0"
 }

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,12 +2,12 @@
   "uuid": "claude-usage@dvdstelt.github.io",
   "name": "Claude Code Usage Monitor",
   "description": "Shows your Claude subscription tier and live usage limits (5-hour and 7-day windows) in the top bar. Reads your existing Claude Code credentials; no extra login required.",
-  "shell-version": ["48", "49", "50"],
+  "shell-version": ["46", "47", "48", "49", "50"],
   "url": "https://github.com/dvdstelt/ClaudeCodeUsage",
   "settings-schema": "org.gnome.shell.extensions.claude-usage",
   "donations": {
     "paypal": "dvdstelt"
   },
-  "version": 9,
-  "version-name": "1.1.2"
+  "version": 10,
+  "version-name": "1.2.0"
 }

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -11,6 +11,11 @@ import {
     AUTHORIZE_URL, TOKEN_URL, CLIENT_ID, REDIRECT_URI, OAUTH_SCOPES,
     DEFAULT_EXPIRES_IN, encoder, decoder,
 } from './lib/oauth.js';
+import {loadProfiles, saveProfiles, makeProfileId, labelForDirName, ensureProfiles} from './lib/profiles.js';
+
+// Gtk.FileDialog predates GJS's automatic async/finish pairing for this
+// class on some GNOME versions, so promisify it explicitly.
+Gio._promisify(Gtk.FileDialog.prototype, 'select_folder', 'select_folder_finish');
 
 // URL-safe base64 without padding, as required by PKCE.
 function base64url(bytes) {
@@ -33,6 +38,26 @@ function codeChallenge(verifier) {
     for (let i = 0; i < 32; i++)
         raw[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
     return base64url(raw);
+}
+
+// Opens a native folder picker rooted at initialPath; returns the chosen path,
+// or null if the user cancelled (or the dialog failed for any reason - not
+// worth surfacing, the user can just try again).
+async function pickFolder(window, initialPath) {
+    const dialog = new Gtk.FileDialog({title: 'Select a Claude Code config folder'});
+    if (initialPath) {
+        try {
+            dialog.set_initial_folder(Gio.File.new_for_path(initialPath));
+        } catch {
+            // Best-effort; the dialog falls back to its own default location.
+        }
+    }
+    try {
+        const folder = await dialog.select_folder(window, null);
+        return folder.get_path();
+    } catch {
+        return null;
+    }
 }
 
 export default class ClaudeUsagePreferences extends ExtensionPreferences {
@@ -128,14 +153,125 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
         behaviour.add(interval);
         settings.bind('poll-seconds', interval, 'value', Gio.SettingsBindFlags.DEFAULT);
 
-        // ---- sign-in (only when Claude Code can't supply a token) ----
-        // If Claude Code is signed in, the extension rides on its credentials
-        // and there's nothing for the user to do here, so the whole group is
-        // omitted rather than shown disabled.
-        if (!(await claudeCodeCredentialsAvailable()))
+        // ---- profiles (one per Claude Code account / config directory) ----
+        await this._addProfilesGroup(page, settings, window);
+
+        // ---- sign-in (only when no profile can supply a Claude Code token) ----
+        // If any profile is signed in via Claude Code, the extension rides on
+        // its credentials and there's nothing to do here for that account, so
+        // the whole group is omitted rather than shown disabled. It reappears
+        // once every profile's on-disk token has expired.
+        const profiles = await ensureProfiles(settings);
+        const anyCredentialed = (await Promise.all(
+            profiles.map(p => claudeCodeCredentialsAvailable(p.configDir)))).some(Boolean);
+        if (!anyCredentialed)
             this._addAuthGroup(page, settings);
 
         this._addAboutGroup(page);
+    }
+
+    // Adds a "Claude profiles" group: one expandable row per configured
+    // profile (name, config folder, remove), plus an "Add profile" row. Each
+    // profile is just a Claude Code config directory (the CLAUDE_CONFIG_DIR
+    // convention for running multiple accounts on one machine); the extension
+    // shows every configured profile side by side and refreshes them together.
+    async _addProfilesGroup(page, settings, window) {
+        const group = new Adw.PreferencesGroup({
+            title: 'Claude profiles',
+            description: 'One row per Claude Code account. A profile is a config ' +
+                'directory such as ~/.claude or ~/.claude-work (the one you get by ' +
+                'running CLAUDE_CONFIG_DIR=~/.claude-work claude). Add one for each ' +
+                'account you want visible - and refreshed - at the same time.',
+        });
+        page.add(group);
+
+        let rows = [];
+        const rerender = () => {
+            for (const row of rows)
+                group.remove(row);
+            // Profile rows first, "Add profile" always last.
+            rows = loadProfiles(settings).map(buildProfileRow);
+            rows.push(buildAddRow());
+        };
+
+        const persist = profiles => {
+            saveProfiles(settings, profiles);
+            rerender();
+        };
+
+        const buildProfileRow = profile => {
+            const row = new Adw.ExpanderRow({title: profile.label, subtitle: profile.configDir});
+            group.add(row);
+
+            const nameRow = new Adw.EntryRow({title: 'Name', text: profile.label, show_apply_button: true});
+            nameRow.connect('apply', () => {
+                const profiles = loadProfiles(settings);
+                const p = profiles.find(x => x.id === profile.id);
+                if (p) {
+                    p.label = nameRow.get_text().trim() || p.label;
+                    persist(profiles);
+                }
+            });
+            row.add_row(nameRow);
+
+            const folderRow = new Adw.ActionRow({title: 'Config folder', subtitle: profile.configDir});
+            const changeBtn = new Gtk.Button({label: 'Change…', valign: Gtk.Align.CENTER});
+            changeBtn.connect('clicked', async () => {
+                const dir = await pickFolder(window, profile.configDir);
+                if (!dir)
+                    return;
+                const profiles = loadProfiles(settings);
+                const p = profiles.find(x => x.id === profile.id);
+                if (p) {
+                    p.configDir = dir;
+                    persist(profiles);
+                }
+            });
+            folderRow.add_suffix(changeBtn);
+            row.add_row(folderRow);
+
+            const removeRow = new Adw.ActionRow({title: 'Remove this profile'});
+            const removeBtn = new Gtk.Button({
+                label: 'Remove', valign: Gtk.Align.CENTER, css_classes: ['destructive-action'],
+            });
+            removeBtn.connect('clicked', () => {
+                persist(loadProfiles(settings).filter(x => x.id !== profile.id));
+            });
+            removeRow.add_suffix(removeBtn);
+            row.add_row(removeRow);
+
+            return row;
+        };
+
+        const buildAddRow = () => {
+            const row = new Adw.ActionRow({
+                title: 'Add profile',
+                subtitle: 'Point at another Claude Code config directory',
+            });
+            const addBtn = new Gtk.Button({
+                label: 'Add…', valign: Gtk.Align.CENTER, css_classes: ['suggested-action'],
+            });
+            addBtn.connect('clicked', async () => {
+                const dir = await pickFolder(window, GLib.get_home_dir());
+                if (!dir)
+                    return;
+                const profiles = loadProfiles(settings);
+                if (profiles.some(p => p.configDir === dir))
+                    return;
+                profiles.push({
+                    id: makeProfileId(),
+                    label: labelForDirName(GLib.path_get_basename(dir)),
+                    configDir: dir,
+                });
+                persist(profiles);
+            });
+            row.add_suffix(addBtn);
+            group.add(row);
+            return row;
+        };
+
+        await ensureProfiles(settings);
+        rerender();
     }
 
     // Adds a centered footer crediting the author, linking to the project for

--- a/src/schemas/org.gnome.shell.extensions.claude-usage.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.claude-usage.gschema.xml
@@ -48,6 +48,16 @@
       <summary>Refresh interval</summary>
       <description>How often, in seconds, to poll for updated usage.</description>
     </key>
+    <key name="profiles" type="s">
+      <default>'[]'</default>
+      <summary>Configured Claude Code profiles</summary>
+      <description>JSON array of {id, label, configDir} objects, one per Claude Code profile (a directory such as ~/.claude or ~/.claude-work holding its own .credentials.json).</description>
+    </key>
+    <key name="profiles-initialized" type="b">
+      <default>false</default>
+      <summary>Whether the profile list has been seeded</summary>
+      <description>Set once auto-detection has populated "profiles" for the first time, so a user who removes every profile afterwards isn't re-seeded.</description>
+    </key>
     <key name="access-token" type="s">
       <default>''</default>
       <summary>OAuth access token</summary>

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -40,6 +40,23 @@
     color: rgba(128, 128, 128, 1.0);
     font-weight: bold;
 }
+.cu-panel-block {
+    spacing: 5px;
+}
+.cu-panel-sep {
+    width: 1px;
+    height: 14px;
+    margin: 0 6px;
+    background-color: rgba(128, 128, 128, 0.35);
+}
+.cu-panel-chip {
+    font-size: 8pt;
+    font-weight: bold;
+    color: rgba(128, 128, 128, 1.0);
+    padding: 1px 4px;
+    border-radius: 4px;
+    background-color: rgba(128, 128, 128, 0.18);
+}
 
 /* ===== popup ===== */
 .cu-popup {
@@ -73,6 +90,20 @@
     font-weight: bold;
     color: rgba(128, 128, 128, 1.0);
     margin: 10px 0 8px 0;
+}
+
+/* ===== per-profile sections ===== */
+.cu-profile-section {
+    margin-bottom: 2px;
+}
+.cu-profile-section-divider {
+    border-top: 1px solid rgba(128, 128, 128, 0.25);
+    padding-top: 12px;
+    margin-top: 10px;
+}
+.cu-profile-header {
+    spacing: 8px;
+    margin-bottom: 10px;
 }
 
 /* ===== meters ===== */
@@ -138,12 +169,13 @@
     padding-top: 9px;
     border-top: 1px solid rgba(128, 128, 128, 0.25);
 }
-.cu-updated { font-size: 9pt; color: rgba(128, 128, 128, 1.0); }
+.cu-updated { font-size: 9pt; color: rgba(128, 128, 128, 1.0); margin-top: 6px; }
 .cu-refresh {
     font-size: 9pt;
     font-weight: bold;
     color: #62a0ea;
-    padding: 2px 6px;
+    padding: 4px 6px;
     border-radius: 6px;
+    text-align: center;
 }
 .cu-refresh:hover { background-color: rgba(128, 128, 128, 0.20); }

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -139,6 +139,8 @@
     color: #ff9c8a;
     margin: 4px 0;
 }
+/* Signed-out note: same slot as an error, but muted — it's a state, not a fault. */
+.cu-error.cu-dim { color: rgba(128, 128, 128, 1.0); }
 
 /* ===== actions ===== */
 .cu-actions {

--- a/tools/poll.js
+++ b/tools/poll.js
@@ -1,14 +1,30 @@
 #!/usr/bin/env -S gjs -m
 // Standalone check: validates the usage client against the live API.
-//   gjs -m tools/poll.js   (run from the repository root)
+//   gjs -m tools/poll.js                    (uses ~/.claude)
+//   gjs -m tools/poll.js ~/.claude-work      (a second Claude Code profile)
 import GLib from 'gi://GLib';
-import {UsageClient} from '../src/lib/usageClient.js';
+import {UsageClient, defaultConfigDir} from '../src/lib/usageClient.js';
 
 const loop = GLib.MainLoop.new(null, false);
 
-async function run() {
-    const client = new UsageClient();
+// GJS exposes extra script arguments as the global ARGV regardless of module
+// mode. Accept an absolute path, a ~/-relative path, or a path relative to cwd.
+function resolveConfigDir(arg) {
+    if (!arg)
+        return defaultConfigDir();
+    if (arg.startsWith('~/'))
+        return GLib.build_filenamev([GLib.get_home_dir(), arg.slice(2)]);
+    if (GLib.path_is_absolute(arg))
+        return arg;
+    return GLib.build_filenamev([GLib.get_current_dir(), arg]);
+}
 
+const configDir = resolveConfigDir(typeof ARGV !== 'undefined' ? ARGV[0] : undefined);
+
+async function run() {
+    const client = new UsageClient({configDir});
+
+    print('config dir:', configDir);
     print('tier (from disk):', JSON.stringify(await client.tierFromDisk()));
 
     const profile = await client.fetchProfile();


### PR DESCRIPTION
### Added
- Support for multiple Claude Code profiles (separate `CLAUDE_CONFIG_DIR`
  accounts, e.g. `~/.claude` and `~/.claude-work`). All configured profiles are
  shown side by side in the panel and the dropdown, and refresh together with
  a single "Refresh all" action. Profiles are auto-detected on first run and
  can be renamed, repointed, added, or removed from a new "Claude profiles"
  group in preferences.

### Changed
- GNOME Shell 46 and 47 are now supported (previously 48-50 only), covering
  Ubuntu 24.04 LTS.