### PR TITLE
Per-profile headers, per-profile sign-in, and panel tweaks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 A GNOME Shell panel indicator that shows your Claude subscription tier and live
 usage limits (5-hour and 7-day windows). It reuses the OAuth token that Claude
-Code already stores on disk, so there is usually no separate login. When Claude
-Code is not signed in, prefs offers an in-app PKCE sign-in as a fallback; that
-sign-in group is hidden whenever Claude Code credentials are present.
+Code already stores on disk, so there is usually no separate login. Each profile
+can also sign in on its own, from a PKCE flow in its row in prefs, for accounts
+that never use the CLI.
 
 ## Layout
 
@@ -21,15 +21,17 @@ the LICENSE, `build.sh`, `tools/`) is repo tooling that stays out of the bundle.
   uniformly). A small chip (e.g. "TE") tags each panel block only when more
   than one profile is configured.
 - `src/prefs.js` — Adwaita preferences (element toggles, panel window, refresh
-  interval, the "Claude profiles" list), bound to GSettings. Also hosts the
-  fallback PKCE sign-in flow, shown only when no configured profile has usable
-  on-disk credentials (`claudeCodeCredentialsAvailable(configDir)` for every
-  profile).
+  interval, the "Claude profiles" list), bound to GSettings. Each profile row
+  carries its own PKCE sign-in (`_addSignInRows`): a status line that reads
+  "Using Claude Code", "Connected", or "Not connected", plus Connect, a field
+  for the pasted code, and Disconnect.
 - `src/schemas/` — GSettings schema (`org.gnome.shell.extensions.claude-usage`).
   Keys: `show-icon`/`show-percentage`/`show-tier`/`show-reset` (bool),
   `panel-gauge` (`ring`|`bar`|`none`),
   `panel-window` (`five-hour`|`seven-day`|`max`|`worst`), `poll-seconds` (30-600),
   `profiles` (JSON string, array of `{id, label, configDir}`),
+  `profile-tokens` (JSON string, profile id -> in-app tokens),
+  `show-profile-chip` (bool),
   `profiles-initialized` (bool, set once auto-detection has seeded `profiles`
   so a deliberately-emptied list isn't re-seeded), and the in-app sign-in
   tokens `access-token`/`refresh-token` (string) + `expires-at` (int64 ms).
@@ -38,11 +40,11 @@ the LICENSE, `build.sh`, `tools/`) is repo tooling that stays out of the bundle.
   `configDir` (that profile's on-disk credentials first, the extension's own
   GSettings tokens second), calls the usage and profile endpoints, refreshes the
   token when near expiry, and writes it back to whichever store it came from.
-  Only one in-app sign-in is supported, so the `allowSharedToken` option gates
-  the fallback to that token to just the profile it can belong to (the sole
-  profile, or the one owning `~/.claude` — decided in `extension.js`); any other
-  profile without on-disk credentials resolves to a `SignedOutError` that the
-  panel shows as a muted "Signed out" state. Exports
+  Takes a `profileId` and resolves that profile's own in-app token from
+  `tokenStore.js` when the on-disk credentials are missing or dead; a profile
+  that has never signed in resolves to a `SignedOutError`, which the panel shows
+  as a muted "Signed out" state. `allowSharedToken` now only decides which
+  single profile may claim a pre-per-profile sign-in during migration. Exports
   `claudeCodeCredentialsAvailable(configDir)`, `defaultConfigDir()`
   (`~/.claude`), and `discoverConfigDirs()` (finds `~/.claude` and sibling
   `~/.claude-*` directories that already hold credentials). Soup is pinned
@@ -53,6 +55,12 @@ the LICENSE, `build.sh`, `tools/`) is repo tooling that stays out of the bundle.
   from `discoverConfigDirs()` once, gated by `profiles-initialized`). Kept
   shell-import-free like `usageClient.js` so prefs and plain `gjs` can use it
   too.
+- `src/lib/tokenStore.js` — per-profile in-app OAuth tokens, kept as a JSON
+  object in the `profile-tokens` GSettings key keyed by profile id. Each
+  profile signs in to its own Claude account; `migrateLegacyToken()` moves a
+  pre-per-profile single sign-in onto the one profile entitled to it. No
+  imports at all, so it is unit-testable under plain `node`
+  (`tools/test-tokenStore.mjs`).
 - `src/lib/oauth.js` — shared OAuth/API constants (client id, endpoints,
   scopes, headers) and text codecs, imported by both `usageClient.js` and
   `prefs.js` so the values are defined once. No shell imports.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ gnome-extensions prefs claude-usage@dvdstelt.github.io
 The extension never asks for your password. It uses an OAuth token in one of two ways:
 
 1. **Claude Code (preferred).** If `~/.claude/.credentials.json` contains a valid token, the extension uses it directly. When the token is close to expiry it is refreshed automatically with the stored refresh token and written back to the same file, so it stays valid whether or not Claude Code itself is running. Because the credentials are shared, you stay signed in to both. If those credentials have fully expired (for example you only use Claude Desktop and never sign in to the Claude Code CLI), the extension falls back to the in-app sign-in below.
-2. **In-app sign-in (fallback).** When Claude Code has no valid token, the preferences window shows an **Account** group with a Connect button. It runs a standard PKCE OAuth flow: Connect opens your browser, you authorize, and paste the resulting code back into the preferences window. The tokens are stored in GSettings and refreshed automatically before they expire. This group is hidden whenever Claude Code has a valid token, since there is nothing to do in that case; it reappears once that token expires.
+2. **In-app sign-in (fallback).** Every profile has its own **Connect** button in its row under "Claude profiles", so each profile can sign in to its own Claude account without the CLI. It runs a standard PKCE OAuth flow: Connect opens your browser, you authorize, and paste the resulting code back into the preferences window. Tokens are stored per profile in GSettings and refreshed automatically before they expire. A profile that is already signed in through Claude Code says so and needs nothing here.
 
 ## How it works
 
@@ -118,6 +118,8 @@ The repository is laid out as:
   - `lib/profiles.js` - the profile list (label + config directory), stored as
     JSON in GSettings; auto-detects `~/.claude` and sibling `~/.claude-*`
     directories on first run.
+  - `lib/tokenStore.js` - per-profile in-app OAuth tokens, stored as JSON in
+    GSettings and keyed by profile id.
   - `lib/oauth.js` - shared OAuth/API constants and text codecs used by both
     the usage client and prefs.
   - `schemas/` - GSettings schema. Recompile after edits with

--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ preferences window.
 ## Requirements
 
 - GNOME Shell 46, 47, 48, 49, or 50 (Ubuntu 24.04 LTS and newer).
-- Either:
+- A **Claude Pro or Max subscription**. The extension reports the usage limits
+  that come with a Claude Code subscription, so a free account has nothing to
+  show and cannot be connected - authorization is refused before any token is
+  issued, whether you sign in from the extension or from the CLI.
+- Then either:
   - **Claude Code** signed in (the extension reads
     `~/.claude/.credentials.json`, or another profile directory you configure
     in preferences), or
@@ -89,7 +93,7 @@ gnome-extensions prefs claude-usage@dvdstelt.github.io
 
 ## Authentication
 
-The extension never asks for your password. It uses an OAuth token in one of two ways:
+The extension never asks for your password. It uses an OAuth token in one of two ways. Both require a Claude Pro or Max subscription: a free account is refused at Anthropic's authorization page, since it has no Claude Code usage limits to report.
 
 1. **Claude Code (preferred).** If `~/.claude/.credentials.json` contains a valid token, the extension uses it directly. When the token is close to expiry it is refreshed automatically with the stored refresh token and written back to the same file, so it stays valid whether or not Claude Code itself is running. Because the credentials are shared, you stay signed in to both. If those credentials have fully expired (for example you only use Claude Desktop and never sign in to the Claude Code CLI), the extension falls back to the in-app sign-in below.
 2. **In-app sign-in (fallback).** Every profile has its own **Connect** button in its row under "Claude profiles", so each profile can sign in to its own Claude account without the CLI. It runs a standard PKCE OAuth flow: Connect opens your browser, you authorize, and paste the resulting code back into the preferences window. Tokens are stored per profile in GSettings and refreshed automatically before they expire. A profile that is already signed in through Claude Code says so and needs nothing here.

--- a/src/extension.js
+++ b/src/extension.js
@@ -422,7 +422,7 @@ class ProfileView {
         // Whether a chip is possible at all (more than one profile); the
         // show-profile-chip setting then decides if it is actually shown.
         this._chipAllowed = showChip;
-        this._client = new UsageClient({configDir: profile.configDir, settings, allowSharedToken});
+        this._client = new UsageClient({configDir: profile.configDir, settings, allowSharedToken, profileId: profile.id});
         this._lastUsage = null;
         // Outcome of this profile's last refresh ('ok' | 'error' | 'signed-out'),
         // read by the indicator for the shared "Updated …" line.

--- a/src/extension.js
+++ b/src/extension.js
@@ -416,9 +416,12 @@ class PanelBar {
 // instances are orchestrated by ClaudeUsageIndicator, which shares a single
 // panel icon, poll timer, and countdown across all of them.
 class ProfileView {
-    constructor(profile, settings, panelBox, sectionsBox, showChip, isFirst, allowSharedToken) {
+    constructor(profile, settings, panelBox, sectionsBox, showChip, isFirst, allowSharedToken, path) {
         this.profile = profile;
         this._settings = settings;
+        // Whether a chip is possible at all (more than one profile); the
+        // show-profile-chip setting then decides if it is actually shown.
+        this._chipAllowed = showChip;
         this._client = new UsageClient({configDir: profile.configDir, settings, allowSharedToken});
         this._lastUsage = null;
         // Normalised windows from the last render, cached for the panel
@@ -462,8 +465,16 @@ class ProfileView {
             style_class: isFirst ? 'cu-profile-section' : 'cu-profile-section cu-profile-section-divider',
         });
 
+        // Each profile carries its own logo and name, so the popup reads as a
+        // list of accounts rather than one branded header over anonymous rows.
         const header = new St.BoxLayout({style_class: 'cu-profile-header'});
-        const who = new St.BoxLayout({vertical: true, x_expand: true});
+        this._logo = new St.Icon({
+            gicon: Gio.icon_new_for_string(`${path}/icons/octopus.png`),
+            style_class: 'cu-logo',
+            y_align: Clutter.ActorAlign.CENTER,
+        });
+        header.add_child(this._logo);
+        const who = new St.BoxLayout({vertical: true, x_expand: true, y_align: Clutter.ActorAlign.CENTER});
         this._label = new St.Label({text: profile.label, style_class: 'cu-title'});
         this._subtitle = new St.Label({text: '', style_class: 'cu-subtitle'});
         who.add_child(this._label);
@@ -500,6 +511,10 @@ class ProfileView {
         this._panelPct.visible = this._settings.get_boolean('show-percentage');
         this._panelTier.visible = this._settings.get_boolean('show-tier');
         this._panelReset.visible = this._settings.get_boolean('show-reset');
+        // The chip only exists with more than one profile, and is then
+        // toggleable — some people would rather not spend the panel width.
+        if (this._chip)
+            this._chip.visible = this._chipAllowed && this._settings.get_boolean('show-profile-chip');
     }
 
     async applyTierFromDisk(cancellable) {
@@ -814,6 +829,7 @@ class ProfileView {
         this._panelBlock?.destroy();
 
         // Popup section contents, then the section itself.
+        this._logo?.destroy();
         this._label?.destroy();
         this._subtitle?.destroy();
         this._pill?.destroy();
@@ -829,6 +845,7 @@ class ProfileView {
         this._panelTier = null;
         this._panelSep = null;
         this._panelBlock = null;
+        this._logo = null;
         this._label = null;
         this._subtitle = null;
         this._pill = null;
@@ -885,6 +902,7 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
             'changed::show-percentage', () => this._applyVisibility(),
             'changed::show-tier', () => this._applyVisibility(),
             'changed::show-reset', () => this._applyVisibility(),
+            'changed::show-profile-chip', () => this._applyVisibility(),
             'changed::panel-window', () => this._renderAllPanels(),
             'changed::poll-seconds', () => this._startTimer(),
             // Signing in (or out) from prefs changes the token source; refetch.
@@ -922,7 +940,7 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
             const ownsDefaultDir = Gio.File.new_for_path(profile.configDir).equal(defaultDir);
             const allowSharedToken = profiles.length === 1 || ownsDefaultDir;
             return new ProfileView(profile, this._settings, this._panelBox,
-                this._sectionsBox, showChip, i === 0, allowSharedToken);
+                this._sectionsBox, showChip, i === 0, allowSharedToken, this._path);
         });
         this._applyVisibility();
         for (const view of this._profileViews)
@@ -947,20 +965,8 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         item.add_child(root);
         this.menu.addMenuItem(item);
 
-        // header (static branding; per-profile identity lives in each section)
-        const header = new St.BoxLayout({style_class: 'cu-header'});
-        const logo = new St.Icon({
-            gicon: Gio.icon_new_for_string(`${this._path}/icons/octopus.png`),
-            style_class: 'cu-logo',
-            y_align: Clutter.ActorAlign.CENTER,
-        });
-        const who = new St.BoxLayout({vertical: true, x_expand: true, y_align: Clutter.ActorAlign.CENTER});
-        who.add_child(new St.Label({text: 'Claude', style_class: 'cu-title'}));
-        who.add_child(new St.Label({text: 'usage', style_class: 'cu-subtitle'}));
-        header.add_child(logo);
-        header.add_child(who);
-        root.add_child(header);
-
+        // No global header: each profile section carries its own logo and name,
+        // so a single-profile popup looks the way it always did.
         // One section per profile, rebuilt whenever the profile list changes.
         this._sectionsBox = new St.BoxLayout({vertical: true});
         root.add_child(this._sectionsBox);

--- a/src/extension.js
+++ b/src/extension.js
@@ -419,9 +419,6 @@ class ProfileView {
     constructor(profile, settings, panelBox, sectionsBox, showChip, isFirst, allowSharedToken, path) {
         this.profile = profile;
         this._settings = settings;
-        // Whether a chip is possible at all (more than one profile); the
-        // show-profile-chip setting then decides if it is actually shown.
-        this._chipAllowed = showChip;
         this._client = new UsageClient({configDir: profile.configDir, settings, allowSharedToken, profileId: profile.id});
         this._lastUsage = null;
         // Outcome of this profile's last refresh ('ok' | 'error' | 'signed-out'),
@@ -512,10 +509,10 @@ class ProfileView {
         this._panelPct.visible = this._settings.get_boolean('show-percentage');
         this._panelTier.visible = this._settings.get_boolean('show-tier');
         this._panelReset.visible = this._settings.get_boolean('show-reset');
-        // The chip only exists with more than one profile, and is then
+        // The chip is only built with more than one profile, and is then
         // toggleable — some people would rather not spend the panel width.
         if (this._chip)
-            this._chip.visible = this._chipAllowed && this._settings.get_boolean('show-profile-chip');
+            this._chip.visible = this._settings.get_boolean('show-profile-chip');
     }
 
     async applyTierFromDisk(cancellable) {

--- a/src/extension.js
+++ b/src/extension.js
@@ -424,6 +424,9 @@ class ProfileView {
         this._chipAllowed = showChip;
         this._client = new UsageClient({configDir: profile.configDir, settings, allowSharedToken});
         this._lastUsage = null;
+        // Outcome of this profile's last refresh ('ok' | 'error' | 'signed-out'),
+        // read by the indicator for the shared "Updated …" line.
+        this.lastResult = null;
         // Normalised windows from the last render, cached for the panel
         // selector and the between-poll countdown.
         this._windows = [];
@@ -498,8 +501,6 @@ class ProfileView {
         this._error.visible = false;
         this._section.add_child(this._error);
 
-        this._updated = new St.Label({text: 'Loading…', style_class: 'cu-updated'});
-        this._section.add_child(this._updated);
 
         sectionsBox.add_child(this._section);
     }
@@ -609,9 +610,7 @@ class ProfileView {
         this._renderSpend(usage);
 
         this.renderPanel();
-
-        const now = GLib.DateTime.new_now_local();
-        this._updated.text = `Updated ${now.format('%H:%M:%S')}`;
+        this.lastResult = 'ok';
     }
 
     // Renders the "extra usage" line from the normalised spend block (the new
@@ -775,7 +774,7 @@ class ProfileView {
         this._error.text = msg;
         this._error.style_class = 'cu-error';
         this._error.visible = true;
-        this._updated.text = 'Update failed';
+        this.lastResult = 'error';
         logError(e, `claude-usage: refresh failed for "${this.profile.label}"`);
     }
 
@@ -804,8 +803,8 @@ class ProfileView {
         this._error.text = e.message;
         this._error.style_class = 'cu-error cu-dim';
         this._error.visible = true;
-        // Nothing to timestamp; the subtitle and note already say "signed out".
-        this._updated.text = '';
+        // Not a failure: the subtitle and note already say "signed out".
+        this.lastResult = 'signed-out';
     }
 
     // Destroys every widget this view owns, leaf-first, then releases the
@@ -833,7 +832,6 @@ class ProfileView {
         this._label?.destroy();
         this._subtitle?.destroy();
         this._pill?.destroy();
-        this._updated?.destroy();
         this._metersBox?.destroy();
         this._section?.destroy();
 
@@ -849,7 +847,6 @@ class ProfileView {
         this._label = null;
         this._subtitle = null;
         this._pill = null;
-        this._updated = null;
         this._metersBox = null;
         this._section = null;
         this._meterBindings = [];
@@ -983,6 +980,10 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
 
         // footer
         const footer = new St.BoxLayout({style_class: 'cu-footer'});
+        // One timestamp for the whole popup: every profile refreshes in the
+        // same cycle, so a per-profile time would just repeat itself.
+        this._updated = new St.Label({text: 'Loading…', style_class: 'cu-updated', x_expand: true});
+        footer.add_child(this._updated);
         const settingsBtn = new St.Button({label: '⚙ Settings', style_class: 'cu-refresh', x_expand: true});
         settingsBtn.connect('clicked', () => {
             this.menu.close();
@@ -1009,6 +1010,24 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
             this._refresh();
             return GLib.SOURCE_CONTINUE;
         });
+    }
+
+    // One shared timestamp for the whole popup. Every profile refreshes in the
+    // same cycle, so this reports the cycle: the time when at least one profile
+    // updated, "Update failed" when every profile that could have fetched
+    // failed, and nothing at all when they are simply all signed out.
+    _renderUpdatedAt() {
+        if (!this._updated)
+            return;
+        const results = this._profileViews.map(v => v.lastResult);
+        if (results.includes('ok')) {
+            const now = GLib.DateTime.new_now_local();
+            this._updated.text = `Updated ${now.format('%H:%M:%S')}`;
+        } else if (results.includes('error')) {
+            this._updated.text = 'Update failed';
+        } else {
+            this._updated.text = '';
+        }
     }
 
     _applyVisibility() {
@@ -1040,8 +1059,10 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         Promise.allSettled(this._profileViews.map(view => view.refresh(cancellable)))
             .finally(() => {
                 this._busy = false;
-                if (!cancellable.is_cancelled())
-                    this._scheduleCountdown();
+                if (cancellable.is_cancelled())
+                    return;
+                this._renderUpdatedAt();
+                this._scheduleCountdown();
             });
     }
 
@@ -1093,6 +1114,8 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         this._settings.disconnectObject(this);
         this._settings = null;
 
+        this._updated?.destroy();
+        this._updated = null;
         this._refreshBtn?.disconnectObject(this);
         this._refreshBtn?.destroy();
         this._refreshBtn = null;

--- a/src/lib/tokenStore.js
+++ b/src/lib/tokenStore.js
@@ -1,0 +1,86 @@
+// Per-profile OAuth tokens from the in-app (PKCE) sign-in, kept as a JSON
+// object in the "profile-tokens" GSettings key, keyed by profile id:
+//
+//   {"p1abc": {"accessToken": "...", "refreshToken": "...", "expiresAt": 173…}}
+//
+// Each profile signs in to its own Claude account, so a second profile no
+// longer has to borrow the first one's token. Tokens live here rather than in
+// the "profiles" key so that reading or rewriting the profile list (labels,
+// directories) never has to touch credentials.
+//
+// Kept free of `resource:///org/gnome/shell` imports, like the other lib
+// modules, so prefs and plain gjs can use it too.
+
+// The single-token keys this replaces. Still read once per profile so an
+// existing in-app sign-in survives the upgrade (see migrateLegacyToken).
+const LEGACY_ACCESS = 'access-token';
+const LEGACY_REFRESH = 'refresh-token';
+const LEGACY_EXPIRES = 'expires-at';
+
+function loadAll(settings) {
+    try {
+        const parsed = JSON.parse(settings.get_string('profile-tokens'));
+        return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+    } catch {
+        return {};
+    }
+}
+
+function saveAll(settings, map) {
+    settings.set_string('profile-tokens', JSON.stringify(map));
+}
+
+// The stored token set for one profile, or null when it has never signed in.
+export function getToken(settings, profileId) {
+    if (!settings || !profileId)
+        return null;
+    const entry = loadAll(settings)[profileId];
+    return entry?.accessToken ? entry : null;
+}
+
+// Stores (or replaces) one profile's tokens. expiresAt is a millisecond
+// timestamp; pass 0 when the endpoint didn't say.
+export function setToken(settings, profileId, {accessToken, refreshToken = '', expiresAt = 0}) {
+    if (!settings || !profileId)
+        return;
+    const map = loadAll(settings);
+    map[profileId] = {accessToken, refreshToken, expiresAt};
+    saveAll(settings, map);
+}
+
+// Forgets one profile's tokens (used by Disconnect, and when a profile is
+// removed so its credentials don't linger in settings).
+export function clearToken(settings, profileId) {
+    if (!settings || !profileId)
+        return;
+    const map = loadAll(settings);
+    if (profileId in map) {
+        delete map[profileId];
+        saveAll(settings, map);
+    }
+}
+
+// Moves a pre-existing single in-app sign-in onto one profile, once. Before
+// per-profile tokens there was one global token set; without this, upgrading
+// would silently sign that user out. Only runs when the profile has no token of
+// its own, and clears the legacy keys so it can't be claimed twice.
+export function migrateLegacyToken(settings, profileId) {
+    if (!settings || !profileId)
+        return null;
+    if (getToken(settings, profileId))
+        return null;
+    const accessToken = settings.get_string(LEGACY_ACCESS);
+    if (!accessToken)
+        return null;
+
+    const entry = {
+        accessToken,
+        refreshToken: settings.get_string(LEGACY_REFRESH),
+        expiresAt: Number(settings.get_int64(LEGACY_EXPIRES)) || 0,
+    };
+    setToken(settings, profileId, entry);
+    settings.set_string(LEGACY_ACCESS, '');
+    settings.set_string(LEGACY_REFRESH, '');
+    settings.set_int64(LEGACY_EXPIRES, 0);
+    return entry;
+}

--- a/src/lib/usageClient.js
+++ b/src/lib/usageClient.js
@@ -133,8 +133,9 @@ export class UsageError extends Error {
     }
 }
 
-// A profile has no usable credentials of its own and isn't allowed to borrow
-// the shared in-app token. The caller renders a "signed out" state, not an error.
+// A profile has no usable credentials: no Claude Code login in its directory
+// and no in-app sign-in of its own. The caller renders a muted "signed out"
+// state rather than an error, since nothing actually went wrong.
 export class SignedOutError extends UsageError {
     constructor(message = 'Not signed in for this profile.') {
         super(message);
@@ -145,13 +146,13 @@ export class SignedOutError extends UsageError {
 
 export class UsageClient {
     // configDir is the Claude Code config directory to read/write credentials
-    // in (defaults to ~/.claude). settings is optional; when provided it
-    // supplies the extension's own OAuth tokens (from the in-app sign-in) as a
-    // fallback for profiles without usable on-disk credentials.
+    // in (defaults to ~/.claude). profileId selects this profile's own in-app
+    // sign-in from tokenStore.js, used when the on-disk credentials are missing
+    // or dead; a profile that has never signed in resolves to a SignedOutError.
     //
-    // allowSharedToken gates that fallback: the in-app token is a single shared
-    // credential, so only the profile it can belong to may use it (see the
-    // caller). Other profiles resolve to a SignedOutError instead.
+    // allowSharedToken no longer gates everyday use — tokens are per profile —
+    // and only decides which single profile may claim a pre-per-profile sign-in
+    // when migrating it (see _storedToken).
     constructor({configDir = defaultConfigDir(), settings = null, allowSharedToken = true, profileId = null} = {}) {
         this._configDir = configDir;
         this._settings = settings;
@@ -294,7 +295,7 @@ export class UsageClient {
     async _settingsToken() {
         const stored = this._storedToken();
         if (!stored)
-            throw new SignedOutError('No Claude Code login found in this profile\u2019s directory.');
+            throw new SignedOutError('Not signed in. Use Connect in this profile\u2019s settings, or sign in with Claude Code.');
         if (stored.expiresAt && stored.expiresAt - Date.now() > REFRESH_SKEW_MS)
             return stored.accessToken;
         return this._refreshSettingsToken();

--- a/src/lib/usageClient.js
+++ b/src/lib/usageClient.js
@@ -5,6 +5,7 @@ import Gio from 'gi://Gio';
 // Soup) could pick the wrong one.
 import Soup from 'gi://Soup?version=3.0';
 
+import {getToken, setToken, migrateLegacyToken} from './tokenStore.js';
 import {
     USAGE_URL, PROFILE_URL, TOKEN_URL, CLIENT_ID,
     BETA_HEADER, API_VERSION, DEFAULT_EXPIRES_IN,
@@ -151,10 +152,13 @@ export class UsageClient {
     // allowSharedToken gates that fallback: the in-app token is a single shared
     // credential, so only the profile it can belong to may use it (see the
     // caller). Other profiles resolve to a SignedOutError instead.
-    constructor({configDir = defaultConfigDir(), settings = null, allowSharedToken = true} = {}) {
+    constructor({configDir = defaultConfigDir(), settings = null, allowSharedToken = true, profileId = null} = {}) {
         this._configDir = configDir;
         this._settings = settings;
         this._allowSharedToken = allowSharedToken;
+        // Which profile's in-app sign-in to use. Each profile signs in to its
+        // own account, so tokens are looked up by id rather than shared.
+        this._profileId = profileId;
         this._session = new Soup.Session();
         this._session.timeout = 15;
         // Shared in-flight token resolution; see _validToken().
@@ -256,27 +260,43 @@ export class UsageClient {
     }
 
     // Refreshes the extension's own tokens, persisting them back to GSettings.
+    // This profile's stored in-app tokens, migrating a pre-existing global
+    // sign-in onto it the first time (so upgrading doesn't sign anyone out).
+    _storedToken() {
+        if (!this._settings || !this._profileId)
+            return null;
+        const own = getToken(this._settings, this._profileId);
+        if (own)
+            return own;
+        // Upgrade path only: the pre-per-profile single sign-in belongs to
+        // whichever profile could legitimately have been using it, so just that
+        // one may claim it. Otherwise two profiles would race for the same
+        // token on first refresh.
+        return this._allowSharedToken
+            ? migrateLegacyToken(this._settings, this._profileId)
+            : null;
+    }
+
     async _refreshSettingsToken() {
-        const refreshToken = this._settings?.get_string('refresh-token');
-        if (!refreshToken)
+        const stored = this._storedToken();
+        if (!stored?.refreshToken)
             throw new UsageError('Not connected; sign in from extension settings');
-        const data = await this._exchangeRefreshToken(refreshToken);
-        this._settings.set_string('access-token', data.access_token);
-        if (data.refresh_token)
-            this._settings.set_string('refresh-token', data.refresh_token);
-        this._settings.set_int64('expires-at',
-            Date.now() + (data.expires_in ?? DEFAULT_EXPIRES_IN) * 1000);
+        const data = await this._exchangeRefreshToken(stored.refreshToken);
+        setToken(this._settings, this._profileId, {
+            accessToken: data.access_token,
+            refreshToken: data.refresh_token || stored.refreshToken,
+            expiresAt: Date.now() + (data.expires_in ?? DEFAULT_EXPIRES_IN) * 1000,
+        });
         return data.access_token;
     }
 
     // The extension's own access token, refreshing when close to expiry.
     async _settingsToken() {
-        const token = this._settings?.get_string('access-token');
-        if (!token)
-            throw new UsageError('No Claude OAuth token found; sign in with Claude Code or from extension settings');
-        const expiresAt = Number(this._settings.get_int64('expires-at')) || 0;
-        if (expiresAt && expiresAt - Date.now() > REFRESH_SKEW_MS)
-            return token;
+        const stored = this._storedToken();
+        if (!stored)
+            throw new SignedOutError('No Claude Code login found in this profile\u2019s directory.');
+        if (stored.expiresAt && stored.expiresAt - Date.now() > REFRESH_SKEW_MS)
+            return stored.accessToken;
         return this._refreshSettingsToken();
     }
 
@@ -311,16 +331,16 @@ export class UsageClient {
             } catch (e) {
                 // Claude Code's credentials are dead (e.g. its refresh token
                 // expired, which happens when the CLI is unused and only Claude
-                // Desktop is signed in). Fall back to the in-app token only if
-                // this profile may use it; otherwise surface the error.
-                if (this._allowSharedToken && this._settings?.get_string('access-token'))
+                // Desktop is signed in). Fall back to this profile's own in-app
+                // sign-in when it has one; otherwise surface the error.
+                if (this._storedToken())
                     return this._settingsToken();
                 throw e;
             }
         }
-        if (this._allowSharedToken)
-            return this._settingsToken();
-        throw new SignedOutError('No Claude Code login found in this profile’s directory.');
+        // No on-disk credentials: fall back to this profile's own in-app
+        // sign-in, which throws SignedOutError when it has never signed in.
+        return this._settingsToken();
     }
 
     async fetchUsage(cancellable = null) {

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -12,6 +12,7 @@ import {
     DEFAULT_EXPIRES_IN, encoder, decoder,
 } from './lib/oauth.js';
 import {loadProfiles, saveProfiles, makeProfileId, labelForDirName, ensureProfiles} from './lib/profiles.js';
+import {getToken, setToken, clearToken} from './lib/tokenStore.js';
 
 // Gtk.FileDialog predates GJS's automatic async/finish pairing for this
 // class on some GNOME versions, so promisify it explicitly.
@@ -165,17 +166,9 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
         // ---- profiles (one per Claude Code account / config directory) ----
         await this._addProfilesGroup(page, settings, window);
 
-        // ---- sign-in (only when no profile can supply a Claude Code token) ----
-        // If any profile is signed in via Claude Code, the extension rides on
-        // its credentials and there's nothing to do here for that account, so
-        // the whole group is omitted rather than shown disabled. It reappears
-        // once every profile's on-disk token has expired.
-        const profiles = await ensureProfiles(settings);
-        const anyCredentialed = (await Promise.all(
-            profiles.map(p => claudeCodeCredentialsAvailable(p.configDir)))).some(Boolean);
-        if (!anyCredentialed)
-            this._addAuthGroup(page, settings);
-
+        // Sign-in is no longer a single global group: each profile row carries
+        // its own Connect/Disconnect, since every profile signs in to its own
+        // Claude account.
         this._addAboutGroup(page);
     }
 
@@ -239,11 +232,16 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
             folderRow.add_suffix(changeBtn);
             row.add_row(folderRow);
 
+            this._addSignInRows(row, settings, profile);
+
             const removeRow = new Adw.ActionRow({title: 'Remove this profile'});
             const removeBtn = new Gtk.Button({
                 label: 'Remove', valign: Gtk.Align.CENTER, css_classes: ['destructive-action'],
             });
             removeBtn.connect('clicked', () => {
+                // Drop the profile's stored sign-in too, so a removed account's
+                // tokens don't linger in settings.
+                clearToken(settings, profile.id);
                 persist(loadProfiles(settings).filter(x => x.id !== profile.id));
             });
             removeRow.add_suffix(removeBtn);
@@ -335,62 +333,64 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
         return btn;
     }
 
-    // Adds an Authentication group with a PKCE OAuth sign-in flow: Connect opens
-    // the browser, the user pastes back the code, and tokens land in GSettings.
-    _addAuthGroup(page, settings) {
-        const authGroup = new Adw.PreferencesGroup({
-            title: 'Account',
-            description: 'Claude Code was not detected. Sign in so the extension can read your usage.',
-        });
-        page.add(authGroup);
+    // Adds this profile's own sign-in rows: a status line, Connect (which opens
+    // the browser for a PKCE flow), a field to paste the returned code, and
+    // Disconnect. Each profile signs in to its own Claude account, so the tokens
+    // are stored per profile id rather than as one shared credential.
+    _addSignInRows(expander, settings, profile) {
+        const hasInApp = () => getToken(settings, profile.id) !== null;
 
-        const isConnected = () => settings.get_string('access-token') !== '';
-
-        const statusRow = new Adw.ActionRow({title: 'Status'});
+        const statusRow = new Adw.ActionRow({title: 'Sign-in'});
         const statusLabel = new Gtk.Label({valign: Gtk.Align.CENTER});
         statusRow.add_suffix(statusLabel);
-        authGroup.add(statusRow);
+        expander.add_row(statusRow);
 
-        const setStatus = (msg, connected) => {
+        const setStatus = (msg, good) => {
             statusLabel.set_label(msg);
-            statusLabel.set_css_classes(connected ? ['success'] : ['dim-label']);
+            statusLabel.set_css_classes(good ? ['success'] : ['dim-label']);
         };
 
         const connectRow = new Adw.ActionRow({
-            title: 'Connect Claude account',
-            subtitle: 'Opens your browser to authorize the extension.',
+            title: 'Connect this profile',
+            subtitle: 'Opens your browser to authorize this account.',
         });
         const connectButton = new Gtk.Button({
-            label: 'Connect',
-            valign: Gtk.Align.CENTER,
-            css_classes: ['suggested-action'],
+            label: 'Connect', valign: Gtk.Align.CENTER, css_classes: ['suggested-action'],
         });
         connectRow.add_suffix(connectButton);
         connectRow.set_activatable_widget(connectButton);
-        authGroup.add(connectRow);
+        expander.add_row(connectRow);
 
-        const codeRow = new Adw.EntryRow({
-            title: 'Paste code from browser',
-            show_apply_button: true,
-        });
+        const codeRow = new Adw.EntryRow({title: 'Paste code from browser', show_apply_button: true});
         codeRow.set_visible(false);
-        authGroup.add(codeRow);
+        expander.add_row(codeRow);
 
         const disconnectRow = new Adw.ActionRow({
-            title: 'Disconnect',
-            subtitle: 'Remove the stored sign-in.',
+            title: 'Disconnect', subtitle: 'Forget this profile\u2019s in-app sign-in.',
         });
         const disconnectButton = new Gtk.Button({
-            label: 'Disconnect',
-            valign: Gtk.Align.CENTER,
-            css_classes: ['destructive-action'],
+            label: 'Disconnect', valign: Gtk.Align.CENTER, css_classes: ['destructive-action'],
         });
         disconnectRow.add_suffix(disconnectButton);
         disconnectRow.set_activatable_widget(disconnectButton);
-        disconnectRow.set_visible(isConnected());
-        authGroup.add(disconnectRow);
+        disconnectRow.set_visible(hasInApp());
+        expander.add_row(disconnectRow);
 
-        setStatus(isConnected() ? 'Connected' : 'Not connected', isConnected());
+        // Claude Code's own credentials win when they are usable, so say so
+        // rather than implying the user still has to sign in here.
+        const refreshStatus = async () => {
+            if (hasInApp()) {
+                setStatus('Connected', true);
+                disconnectRow.set_visible(true);
+            } else if (await claudeCodeCredentialsAvailable(profile.configDir)) {
+                setStatus('Using Claude Code', true);
+                disconnectRow.set_visible(false);
+            } else {
+                setStatus('Not connected', false);
+                disconnectRow.set_visible(false);
+            }
+        };
+        refreshStatus();
 
         // PKCE state for the in-progress flow.
         let codeVerifier = null;
@@ -411,7 +411,7 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
             Gio.AppInfo.launch_default_for_uri(`${AUTHORIZE_URL}?${params}`, null);
             codeRow.set_text('');
             codeRow.set_visible(true);
-            setStatus('Waiting for code…', false);
+            setStatus('Waiting for code\u2026', false);
         });
 
         codeRow.connect('apply', () => {
@@ -422,7 +422,7 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
 
             // Accept the raw "code#state" the callback page shows, or a full
             // pasted callback URL.
-            let input = codeRow.get_text().trim();
+            const input = codeRow.get_text().trim();
             let code = input;
             let state = oauthState;
             try {
@@ -444,7 +444,7 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
                 return;
             }
 
-            setStatus('Exchanging code…', false);
+            setStatus('Exchanging code\u2026', false);
             connectButton.set_sensitive(false);
 
             const body = JSON.stringify({
@@ -471,11 +471,11 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
                         return;
                     }
                     const resp = JSON.parse(text);
-                    settings.set_string('refresh-token', resp.refresh_token ?? '');
-                    settings.set_int64('expires-at',
-                        Date.now() + (resp.expires_in ?? DEFAULT_EXPIRES_IN) * 1000);
-                    // Set access-token last: the extension watches it to refetch.
-                    settings.set_string('access-token', resp.access_token);
+                    setToken(settings, profile.id, {
+                        accessToken: resp.access_token,
+                        refreshToken: resp.refresh_token ?? '',
+                        expiresAt: Date.now() + (resp.expires_in ?? DEFAULT_EXPIRES_IN) * 1000,
+                    });
                     setStatus('Connected', true);
                     codeRow.set_visible(false);
                     disconnectRow.set_visible(true);
@@ -491,14 +491,11 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
         });
 
         disconnectButton.connect('clicked', () => {
-            settings.set_string('refresh-token', '');
-            settings.set_int64('expires-at', 0);
-            settings.set_string('access-token', '');
-            setStatus('Not connected', false);
-            disconnectRow.set_visible(false);
+            clearToken(settings, profile.id);
             codeRow.set_visible(false);
             codeVerifier = null;
             oauthState = null;
+            refreshStatus();
         });
     }
 }

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -250,6 +250,7 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
                 // Drop the profile's stored sign-in too, so a removed account's
                 // tokens don't linger in settings.
                 clearToken(settings, profile.id);
+                Gio.Settings.sync();
                 persist(loadProfiles(settings).filter(x => x.id !== profile.id));
             });
             removeRow.add_suffix(removeBtn);
@@ -484,6 +485,11 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
                         refreshToken: resp.refresh_token ?? '',
                         expiresAt: Date.now() + (resp.expires_in ?? DEFAULT_EXPIRES_IN) * 1000,
                     });
+                    // prefs is short-lived and may exit as soon as the window
+                    // closes; force the token to disk rather than trusting the
+                    // backend's async flush, or a sign-in done just before
+                    // closing is silently lost.
+                    Gio.Settings.sync();
                     setStatus('Connected', true);
                     codeRow.set_visible(false);
                     disconnectRow.set_visible(true);
@@ -500,6 +506,7 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
 
         disconnectButton.connect('clicked', () => {
             clearToken(settings, profile.id);
+            Gio.Settings.sync();
             codeRow.set_visible(false);
             codeVerifier = null;
             oauthState = null;

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -173,7 +173,8 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
     }
 
     // Adds a "Claude profiles" group: one expandable row per configured
-    // profile (name, config folder, remove), plus an "Add profile" row. Each
+    // profile (name, config folder, its own sign-in, and — only when another
+    // profile would remain — remove), plus an "Add profile" row. Each
     // profile is just a Claude Code config directory (the CLAUDE_CONFIG_DIR
     // convention for running multiple accounts on one machine); the extension
     // shows every configured profile side by side and refreshes them together.
@@ -191,8 +192,12 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
         const rerender = () => {
             for (const row of rows)
                 group.remove(row);
-            // Profile rows first, "Add profile" always last.
-            rows = loadProfiles(settings).map(buildProfileRow);
+            // Profile rows first, "Add profile" always last. Removal is only
+            // offered when another profile would remain: with a single profile
+            // there is nothing to fall back to, and deleting it by accident
+            // leaves an empty panel that is fiddly to recover from.
+            const profiles = loadProfiles(settings);
+            rows = profiles.map(p => buildProfileRow(p, profiles.length > 1));
             rows.push(buildAddRow());
         };
 
@@ -201,7 +206,7 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
             rerender();
         };
 
-        const buildProfileRow = profile => {
+        const buildProfileRow = (profile, canRemove) => {
             const row = new Adw.ExpanderRow({title: profile.label, subtitle: profile.configDir});
             group.add(row);
 
@@ -233,6 +238,9 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
             row.add_row(folderRow);
 
             this._addSignInRows(row, settings, profile);
+
+            if (!canRemove)
+                return row;
 
             const removeRow = new Adw.ActionRow({title: 'Remove this profile'});
             const removeBtn = new Gtk.Button({

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -88,6 +88,14 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
             settings.bind(key, row, 'active', Gio.SettingsBindFlags.DEFAULT);
         }
 
+        // Only has any effect with more than one profile configured.
+        const chipRow = new Adw.SwitchRow({
+            title: 'Profile tag',
+            subtitle: 'Show a short tag (e.g. "DW") before each profile\'s gauge, when you have more than one profile.',
+        });
+        elements.add(chipRow);
+        settings.bind('show-profile-chip', chipRow, 'active', Gio.SettingsBindFlags.DEFAULT);
+
         // Time-until-reset for the window chosen by "Panel reflects" below.
         const resetRow = new Adw.SwitchRow({
             title: 'Time until reset',

--- a/src/schemas/org.gnome.shell.extensions.claude-usage.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.claude-usage.gschema.xml
@@ -32,6 +32,11 @@
       <summary>Show the time until reset</summary>
       <description>Display, in the panel, the time left before the window selected by panel-window resets.</description>
     </key>
+    <key name="show-profile-chip" type="b">
+      <default>true</default>
+      <summary>Show the profile tag</summary>
+      <description>Display a short two-letter tag before each profile's gauge in the panel, to tell profiles apart. Only ever shown when more than one profile is configured.</description>
+    </key>
     <key name="panel-window" type="s">
       <choices>
         <choice value="five-hour"/>

--- a/src/schemas/org.gnome.shell.extensions.claude-usage.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.claude-usage.gschema.xml
@@ -64,6 +64,11 @@
       <summary>Whether the profile list has been seeded</summary>
       <description>Set once auto-detection has populated "profiles" for the first time, so a user who removes every profile afterwards isn't re-seeded.</description>
     </key>
+    <key name="profile-tokens" type="s">
+      <default>'{}'</default>
+      <summary>Per-profile OAuth tokens</summary>
+      <description>JSON object mapping a profile id to its in-app sign-in tokens ({accessToken, refreshToken, expiresAt}). Each profile signs in to its own Claude account; the older single access-token/refresh-token keys are migrated into here on first use.</description>
+    </key>
     <key name="access-token" type="s">
       <default>''</default>
       <summary>OAuth access token</summary>

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -64,12 +64,6 @@
     spacing: 0;
 }
 
-.cu-header {
-    spacing: 11px;
-    padding-bottom: 12px;
-    margin-bottom: 6px;
-    border-bottom: 1px solid rgba(128, 128, 128, 0.25);
-}
 .cu-logo {
     icon-size: 36px;
 }
@@ -102,8 +96,10 @@
     margin-top: 10px;
 }
 .cu-profile-header {
-    spacing: 8px;
-    margin-bottom: 10px;
+    spacing: 11px;
+    padding-bottom: 12px;
+    margin-bottom: 6px;
+    border-bottom: 1px solid rgba(128, 128, 128, 0.25);
 }
 
 /* ===== meters ===== */

--- a/tools/test-tokenStore.mjs
+++ b/tools/test-tokenStore.mjs
@@ -1,0 +1,53 @@
+// Pure-node tests for the per-profile token store (no GI, no network):
+//   node tools/test-tokenStore.mjs
+import {getToken, setToken, clearToken, migrateLegacyToken} from '../src/lib/tokenStore.js';
+
+let pass = 0, fail = 0;
+const ok = (name, cond) => { cond ? (pass++, console.log('  ok  ' + name)) : (fail++, console.log('  FAIL ' + name)); };
+
+// Minimal stand-in for Gio.Settings covering the keys the store touches.
+function fakeSettings(init = {}) {
+    const s = {'profile-tokens': '{}', 'access-token': '', 'refresh-token': '', 'expires-at': 0, ...init};
+    return {
+        get_string: k => s[k], set_string: (k, v) => { s[k] = v; },
+        get_int64: k => s[k], set_int64: (k, v) => { s[k] = v; },
+        _raw: s,
+    };
+}
+
+let st = fakeSettings();
+ok('unknown profile has no token', getToken(st, 'p1') === null);
+
+setToken(st, 'p1', {accessToken: 'A1', refreshToken: 'R1', expiresAt: 123});
+ok('token round-trips', getToken(st, 'p1')?.accessToken === 'A1');
+ok('other profile still empty', getToken(st, 'p2') === null);
+
+setToken(st, 'p2', {accessToken: 'A2'});
+ok('profiles are independent', getToken(st, 'p1').accessToken === 'A1' && getToken(st, 'p2').accessToken === 'A2');
+ok('defaults applied', getToken(st, 'p2').refreshToken === '' && getToken(st, 'p2').expiresAt === 0);
+
+clearToken(st, 'p1');
+ok('clear removes only that profile', getToken(st, 'p1') === null && getToken(st, 'p2').accessToken === 'A2');
+
+// Malformed settings must not throw.
+st = fakeSettings({'profile-tokens': 'not json'});
+ok('malformed JSON degrades to empty', getToken(st, 'p1') === null);
+st = fakeSettings({'profile-tokens': '[1,2,3]'});
+ok('array JSON rejected', getToken(st, 'p1') === null);
+
+// Legacy migration.
+st = fakeSettings({'access-token': 'OLD', 'refresh-token': 'OLDR', 'expires-at': 999});
+const migrated = migrateLegacyToken(st, 'p1');
+ok('legacy token migrates', migrated?.accessToken === 'OLD' && getToken(st, 'p1').refreshToken === 'OLDR');
+ok('legacy keys cleared after migration', st._raw['access-token'] === '' && st._raw['expires-at'] === 0);
+ok('second profile cannot claim it twice', migrateLegacyToken(st, 'p2') === null);
+
+st = fakeSettings({'access-token': 'OLD'});
+setToken(st, 'p1', {accessToken: 'MINE'});
+ok('existing token is not overwritten by migration', migrateLegacyToken(st, 'p1') === null && getToken(st, 'p1').accessToken === 'MINE');
+
+st = fakeSettings();
+ok('no legacy token to migrate', migrateLegacyToken(st, 'p1') === null);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Follow-up to the multi-profile work (#12), fixing how it reads with one profile and making each profile a genuinely independent account.

## Popup layout

The multi-profile popup put static "Claude / usage" branding at the top and left each profile section as a bare name, so a single-profile user saw the logo detached from their account and the word "Claude" twice.

The global header is gone. Each profile now carries **its own octopus next to its own name**, with the account identity in the subtitle and the tier pill on the right:

```
🐙  Dennis Work                      MAX 5x
    Dennis · Claude Code · active
    ─────────────────────────────────
    USAGE LIMITS
```

One profile now looks the way it did before the profile work; several read as a list of accounts.

## Per-profile sign-in

The browser (PKCE) sign-in stored a **single** token in GSettings, so only one account could use it — a second profile either borrowed the first one's credentials or showed as signed out, and the only route to a real second account was the CLI.

Tokens are now stored per profile in a new `profile-tokens` key, keyed by profile id, and Connect / paste-code / Disconnect live in each profile's row. A profile already signed in through Claude Code reads "Using Claude Code" and needs nothing.

**Upgrades are safe:** an existing single sign-in migrates onto the one profile entitled to it the first time that profile resolves a token, so nobody is signed out. `allowSharedToken` now gates only that migration, which stops two profiles racing to claim the same legacy token. Removing a profile forgets its tokens.

## Smaller fixes

- **One shared "Updated" time.** It was rendered inside every profile section, but all profiles refresh in the same cycle, so it just repeated itself. Moved to the footer; it reports the cycle (a time when at least one profile updated, "Update failed" when every profile that could fetch failed, nothing when they are all signed out).
- **Optional panel tag.** New "Profile tag" toggle (`show-profile-chip`, default on) turns off the two-letter chip; it only ever appears with more than one profile.
- **Safer removal.** "Remove this profile" is hidden unless another profile would remain, so the only profile can't be deleted by accident.
- **Documented the subscription requirement.** A free account is refused at the authorization page — from the CLI as well as the extension — and nothing said so, which reads like a broken sign-in rather than an ineligible account.

## Testing

- `node tools/test-tokenStore.mjs` — 13 new pure-node tests covering per-profile isolation, malformed settings JSON, and the migration edge cases (no double-claim, never overwrite an existing token, no-op when there is nothing to migrate).
- `node tools/test-usageModel.mjs` — 10 existing tests still pass.
- `node --check` on all JS, `glib-compile-schemas --strict`, and `./build.sh` all clean; the bundle includes `lib/tokenStore.js`.

## Notes

- Adds two schema keys (`profile-tokens`, `show-profile-chip`), so a dev checkout needs `glib-compile-schemas src/schemas/` before reloading. Store installs compile the schema automatically.
- Version is deliberately left at **1.4.0 / code 12**; the changelog `Unreleased` section and a version bump are still to do before the next upload.