### PR TITLE
Panel placement and an optional shortcut to open the popup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ the LICENSE, `build.sh`, `tools/`) is repo tooling that stays out of the bundle.
   `panel-window` (`five-hour`|`seven-day`|`max`|`worst`), `poll-seconds` (30-600),
   `panel-position` (`left`|`center`|`right`) + `panel-index` (0-20, where the
   indicator sits in that box; applied live by re-registering it in `_place()`),
+  `toggle-menu` (`as`, keyboard shortcut that opens the popup; empty = unbound,
+  registered with `Main.wm.addKeybinding` like the shell's own panel menus),
   `profiles` (JSON string, array of `{id, label, configDir}`),
   `profile-tokens` (JSON string, profile id -> in-app tokens),
   `show-profile-chip` (bool),

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@ the LICENSE, `build.sh`, `tools/`) is repo tooling that stays out of the bundle.
   Keys: `show-icon`/`show-percentage`/`show-tier`/`show-reset` (bool),
   `panel-gauge` (`ring`|`bar`|`none`),
   `panel-window` (`five-hour`|`seven-day`|`max`|`worst`), `poll-seconds` (30-600),
+  `panel-position` (`left`|`center`|`right`) + `panel-index` (0-20, where the
+  indicator sits in that box; applied live by re-registering it in `_place()`),
   `profiles` (JSON string, array of `{id, label, configDir}`),
   `profile-tokens` (JSON string, profile id -> in-app tokens),
   `show-profile-chip` (bool),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ Thanks to @rafi0x for the multiple-profile support.
   group in preferences.
 - A profile whose config directory has no Claude Code login is now shown as
   signed out, instead of silently displaying another account's usage.
+- Each profile can sign in to its own Claude account, from its own row in
+  preferences, so a second account no longer needs the Claude Code CLI. Tokens
+  are kept per profile, and an existing single sign-in is carried over on
+  upgrade rather than being lost.
+- The indicator can be placed in any section of the top bar - left, center, or
+  right - and positioned among the other items there, without needing a
+  separate panel-organiser extension (#1).
+- An optional keyboard shortcut opens the usage popup, the way `Super+S` opens
+  GNOME's quick settings. Not set by default (#13).
+- A "Profile tag" toggle hides the short two-letter tag shown before each
+  profile's gauge, for anyone who would rather keep the panel narrow.
 
 ### Changed
 - GNOME Shell 46 and 47 are now supported (previously 48-50 only), covering
@@ -29,6 +40,13 @@ Thanks to @rafi0x for the multiple-profile support.
   header shows the profile's own label.
 - The subscription pill follows the plan the API reports rather than a fixed
   list, so team and enterprise seats are labelled correctly.
+- Each profile has its own header in the popup - its own logo and the name you
+  gave it - instead of one static heading above the list. With a single profile
+  the popup reads the way it did before profiles existed.
+- The "Updated" time sits once at the bottom of the popup instead of being
+  repeated in every profile section, since all profiles refresh together.
+- "Remove this profile" is only offered when another profile would remain, so
+  the last one cannot be deleted by accident.
 
 ## 1.3.0 - 2026-08-21
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ gnome-extensions prefs claude-usage@dvdstelt.github.io
 - **Panel elements** - show or hide the icon, percentage, time until reset, and tier, and choose the usage gauge (circle, bar, or none).
 - **Panel reflects** - which window the ring, percentage, and time-until-reset countdown track: the 5-hour window, the 7-day window, or whichever is most constrained.
 - **Panel position** - which section of the top bar the indicator sits in (left, center, or right), and where it sits among the other items there. Changes apply immediately.
+- **Shortcut to open the popup** - an optional keyboard shortcut that opens the usage dropdown, the way `Super+S` opens GNOME's quick settings. Not set by default; click the row to record one, or the clear button to remove it.
 - **Refresh interval** - how often to poll for updated usage (30 to 600 seconds; default 300).
 
 ## Authentication

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ gnome-extensions prefs claude-usage@dvdstelt.github.io
 
 - **Panel elements** - show or hide the icon, percentage, time until reset, and tier, and choose the usage gauge (circle, bar, or none).
 - **Panel reflects** - which window the ring, percentage, and time-until-reset countdown track: the 5-hour window, the 7-day window, or whichever is most constrained.
+- **Panel position** - which section of the top bar the indicator sits in (left, center, or right), and where it sits among the other items there. Changes apply immediately.
 - **Refresh interval** - how often to poll for updated usage (30 to 600 seconds; default 300).
 
 ## Authentication

--- a/src/extension.js
+++ b/src/extension.js
@@ -4,6 +4,8 @@ import Clutter from 'gi://Clutter';
 import GLib from 'gi://GLib';
 import Gio from 'gi://Gio';
 import Pango from 'gi://Pango';
+import Meta from 'gi://Meta';
+import Shell from 'gi://Shell';
 import Cairo from 'cairo';
 
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
@@ -1143,6 +1145,18 @@ export default class ClaudeUsageExtension extends Extension {
             'changed::panel-index', () => this._place(),
             this);
         this._place();
+
+        // Optional shortcut that opens the popup, the same as clicking the
+        // indicator — the shell binds its own panel menus this way (Super+S
+        // for quick settings). Unbound by default, so nothing is taken from
+        // the user until they choose a combination. Meta follows the GSettings
+        // key itself, so changing the shortcut needs no extra plumbing.
+        Main.wm.addKeybinding(
+            'toggle-menu',
+            this._settings,
+            Meta.KeyBindingFlags.IGNORE_AUTOREPEAT,
+            Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
+            () => this._indicator?.menu.toggle());
     }
 
     // Puts the indicator in the configured panel box. addToStatusArea refuses a
@@ -1159,6 +1173,7 @@ export default class ClaudeUsageExtension extends Extension {
     }
 
     disable() {
+        Main.wm.removeKeybinding('toggle-menu');
         this._settings?.disconnectObject(this);
         this._settings = null;
         this._indicator?.destroy();

--- a/src/extension.js
+++ b/src/extension.js
@@ -1133,11 +1133,34 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
 
 export default class ClaudeUsageExtension extends Extension {
     enable() {
-        this._indicator = new ClaudeUsageIndicator(this.path, this.getSettings(), () => this.openPreferences());
-        Main.panel.addToStatusArea(this.uuid, this._indicator);
+        this._settings = this.getSettings();
+        this._indicator = new ClaudeUsageIndicator(
+            this.path, this._settings, () => this.openPreferences());
+        // Watch both placement keys so a move applies immediately, with no
+        // reload and no logging out.
+        this._settings.connectObject(
+            'changed::panel-position', () => this._place(),
+            'changed::panel-index', () => this._place(),
+            this);
+        this._place();
+    }
+
+    // Puts the indicator in the configured panel box. addToStatusArea refuses a
+    // role that is already registered, so the registration is cleared first;
+    // the indicator itself is reused, so moving it costs no refetch and leaves
+    // the poll timer and current readings alone.
+    _place() {
+        if (Main.panel.statusArea[this.uuid])
+            Main.panel.statusArea[this.uuid] = null;
+        Main.panel.addToStatusArea(
+            this.uuid, this._indicator,
+            this._settings.get_int('panel-index'),
+            this._settings.get_string('panel-position'));
     }
 
     disable() {
+        this._settings?.disconnectObject(this);
+        this._settings = null;
         this._indicator?.destroy();
         this._indicator = null;
     }

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -150,6 +150,34 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
         });
         behaviour.add(windowRow);
 
+        const positions = new Gtk.StringList();
+        positions.append('Left');
+        positions.append('Center');
+        positions.append('Right');
+        const positionKeys = ['left', 'center', 'right'];
+
+        const positionRow = new Adw.ComboRow({
+            title: 'Panel position',
+            subtitle: 'Which section of the top bar the indicator sits in.',
+            model: positions,
+        });
+        positionRow.selected = Math.max(0, positionKeys.indexOf(settings.get_string('panel-position')));
+        positionRow.connect('notify::selected', () => {
+            settings.set_string('panel-position', positionKeys[positionRow.selected]);
+        });
+        settings.connect('changed::panel-position', () => {
+            positionRow.selected = Math.max(0, positionKeys.indexOf(settings.get_string('panel-position')));
+        });
+        behaviour.add(positionRow);
+
+        const indexRow = new Adw.SpinRow({
+            title: 'Position in that section',
+            subtitle: 'Raise this to move the indicator further along; 0 puts it first.',
+            adjustment: new Gtk.Adjustment({lower: 0, upper: 20, step_increment: 1, page_increment: 5}),
+        });
+        behaviour.add(indexRow);
+        settings.bind('panel-index', indexRow, 'value', Gio.SettingsBindFlags.DEFAULT);
+
         const interval = new Adw.SpinRow({
             title: 'Refresh interval',
             subtitle: 'Seconds between usage updates.',

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -1,5 +1,6 @@
 import Adw from 'gi://Adw';
 import Gtk from 'gi://Gtk';
+import Gdk from 'gi://Gdk';
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import Soup from 'gi://Soup?version=3.0';
@@ -178,6 +179,8 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
         behaviour.add(indexRow);
         settings.bind('panel-index', indexRow, 'value', Gio.SettingsBindFlags.DEFAULT);
 
+        behaviour.add(this._buildShortcutRow(settings, window));
+
         const interval = new Adw.SpinRow({
             title: 'Refresh interval',
             subtitle: 'Seconds between usage updates.',
@@ -320,6 +323,100 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
 
     // Adds a centered footer crediting the author, linking to the project for
     // bug reports and feature requests, and showing the version.
+    // A row showing the current shortcut for opening the popup, which opens a
+    // small capture dialog when activated. The key is an "as" array, matching
+    // how the shell stores its own keybindings.
+    _buildShortcutRow(settings, window) {
+        const row = new Adw.ActionRow({
+            title: 'Shortcut to open the popup',
+            subtitle: 'Opens the usage dropdown without the mouse. Not set by default.',
+            activatable: true,
+        });
+
+        const label = new Gtk.ShortcutLabel({
+            disabled_text: 'Not set',
+            valign: Gtk.Align.CENTER,
+        });
+        const syncLabel = () => {
+            label.set_accelerator(settings.get_strv('toggle-menu')[0] ?? '');
+        };
+        syncLabel();
+        settings.connect('changed::toggle-menu', syncLabel);
+        row.add_suffix(label);
+
+        const clear = new Gtk.Button({
+            icon_name: 'edit-clear-symbolic',
+            valign: Gtk.Align.CENTER,
+            css_classes: ['flat'],
+            tooltip_text: 'Clear the shortcut',
+        });
+        clear.connect('clicked', () => settings.set_strv('toggle-menu', []));
+        row.add_suffix(clear);
+
+        row.connect('activated', () => this._captureShortcut(settings, window));
+        return row;
+    }
+
+    // Modal that grabs the next key combination. Escape cancels, Backspace
+    // clears, and a bare key without modifiers is ignored — otherwise typing a
+    // letter would steal it system-wide.
+    _captureShortcut(settings, window) {
+        const dialog = new Adw.Window({
+            modal: true,
+            transient_for: window,
+            default_width: 380,
+            default_height: 180,
+            title: 'Set shortcut',
+        });
+
+        const view = new Adw.ToolbarView();
+        view.add_top_bar(new Adw.HeaderBar({show_end_title_buttons: false, show_start_title_buttons: false}));
+        const box = new Gtk.Box({
+            orientation: Gtk.Orientation.VERTICAL,
+            valign: Gtk.Align.CENTER,
+            spacing: 8,
+            margin_start: 24, margin_end: 24, margin_top: 12, margin_bottom: 24,
+        });
+        box.append(new Gtk.Label({
+            label: 'Press the key combination you want to use.',
+            wrap: true,
+        }));
+        box.append(new Gtk.Label({
+            label: 'Esc to cancel, Backspace to clear.',
+            wrap: true,
+            css_classes: ['dim-label'],
+        }));
+        view.set_content(box);
+        dialog.set_content(view);
+
+        const controller = new Gtk.EventControllerKey({propagation_phase: Gtk.PropagationPhase.CAPTURE});
+        controller.connect('key-pressed', (_c, keyval, keycode, state) => {
+            const mask = state & Gtk.accelerator_get_default_mod_mask();
+
+            if (keyval === Gdk.KEY_Escape && !mask) {
+                dialog.close();
+                return Gdk.EVENT_STOP;
+            }
+            if (keyval === Gdk.KEY_BackSpace && !mask) {
+                settings.set_strv('toggle-menu', []);
+                dialog.close();
+                return Gdk.EVENT_STOP;
+            }
+            // A modifier on its own, or a plain unmodified key, is not a usable
+            // global shortcut; keep waiting instead of storing something that
+            // would swallow ordinary typing.
+            if (!mask || !Gtk.accelerator_valid(keyval, mask))
+                return Gdk.EVENT_STOP;
+
+            const accel = Gtk.accelerator_name_with_keycode(null, keyval, keycode, mask);
+            settings.set_strv('toggle-menu', [accel]);
+            dialog.close();
+            return Gdk.EVENT_STOP;
+        });
+        dialog.add_controller(controller);
+        dialog.present();
+    }
+
     _addAboutGroup(page) {
         const footer = new Adw.PreferencesGroup();
         page.add(footer);

--- a/src/schemas/org.gnome.shell.extensions.claude-usage.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.claude-usage.gschema.xml
@@ -48,6 +48,22 @@
       <summary>Panel usage window</summary>
       <description>Which usage window the panel ring and percentage reflect: the 5-hour window, the 7-day window, the one with the highest utilization (max), or the worst active limit by severity (worst) — the latter surfaces a maxed-out per-model window such as Fable.</description>
     </key>
+    <key name="panel-position" type="s">
+      <choices>
+        <choice value="left"/>
+        <choice value="center"/>
+        <choice value="right"/>
+      </choices>
+      <default>"right"</default>
+      <summary>Panel box</summary>
+      <description>Which section of the top bar the indicator sits in: left (next to Activities), center (by the clock), or right (the status area).</description>
+    </key>
+    <key name="panel-index" type="i">
+      <range min="0" max="20"/>
+      <default>0</default>
+      <summary>Position within the panel box</summary>
+      <description>Where the indicator sits among the other items in its panel box. 0 is the first slot; larger values move it further along. Values beyond the number of items simply place it last.</description>
+    </key>
     <key name="poll-seconds" type="i">
       <range min="30" max="600"/>
       <default>300</default>

--- a/src/schemas/org.gnome.shell.extensions.claude-usage.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.claude-usage.gschema.xml
@@ -64,6 +64,11 @@
       <summary>Position within the panel box</summary>
       <description>Where the indicator sits among the other items in its panel box. 0 is the first slot; larger values move it further along. Values beyond the number of items simply place it last.</description>
     </key>
+    <key name="toggle-menu" type="as">
+      <default><![CDATA[[]]]></default>
+      <summary>Shortcut to open the usage popup</summary>
+      <description>Keyboard shortcut that opens and closes the usage dropdown, the same as clicking the panel indicator. Empty means no shortcut is bound.</description>
+    </key>
     <key name="poll-seconds" type="i">
       <range min="30" max="600"/>
       <default>300</default>


### PR DESCRIPTION
Closes #1. Closes #13.

Two independent feature requests, combined into one branch because they touch the same files (schema, prefs, `enable()`/`disable()`, docs).

## Panel placement (#1)

The indicator was always added to the right-hand status area, so anyone who wanted it elsewhere had to install a separate panel-organiser extension.

- `panel-position` — `left` / `center` / `right`, defaulting to `right` so nothing moves for existing users
- `panel-index` — where it sits among the other items in that box
- Both passed to `addToStatusArea`, with matching rows under Preferences ▸ Behaviour

Both keys are watched, so a move applies **immediately** — no reload, no logging out. Re-registering **reuses the existing indicator** rather than rebuilding it (clearing `Main.panel.statusArea[uuid]` first, the way IP-Finder and netident do), so moving costs no refetch and leaves the poll timer and current readings untouched. Rebuilding it would have fired a fresh request on every nudge of the spinner, which is exactly what trips the 429 throttle.

## Optional shortcut (#13)

A global shortcut that opens the usage popup, so the limits can be checked without the mouse.

- `toggle-menu` keybinding (`as`, matching how the shell stores its own), registered with `Main.wm.addKeybinding` → `indicator.menu.toggle()`
- A shortcut row in preferences that records a combination, with a clear button

This follows an established pattern rather than inventing one: GNOME binds its own panel menus the same way (`Super+S` for quick settings, `Super+V` for the message tray), and the official `apps-menu` extension registers a toggle for its top-bar menu with the identical call.

Two deliberate choices:

- **Unbound by default.** Shipping a default risks stealing a combination the user already relies on.
- **A keypress with no modifiers is ignored.** `Gtk.accelerator_valid(Gdk.KEY_u, 0)` returns `true`, so GTK will happily accept a bare letter — binding one would swallow ordinary typing system-wide. The explicit modifier check is what prevents that, so it should not be "simplified" away.

## Testing

- `node --check` on all JS; `glib-compile-schemas --strict`; `./build.sh` clean
- `node tools/test-tokenStore.mjs` (13) and `node tools/test-usageModel.mjs` (10) still pass
- The GTK4 shortcut APIs were exercised under `gjs` to confirm they behave as used (`ShortcutLabel.set_accelerator`, `accelerator_get_default_mod_mask`, `accelerator_valid`, `accelerator_name_with_keycode`, the `Gdk.KEY_*` constants)

**Not verified live:** the keybinding actually firing needs a session relog, which I could not do here. Worth confirming after logging back in.

## Notes

- Adds three schema keys (`panel-position`, `panel-index`, `toggle-menu`), so a dev checkout needs `glib-compile-schemas src/schemas/` before reloading. Store installs compile the schema on install.
- The changelog's 1.4.0 entry now also covers what landed after it was first written (per-profile sign-in, the popup headers, the shared "Updated" line, the profile-tag toggle, the last-profile guard) alongside these two features. Version stays at 1.4.0 / code 12, which is still unpublished.