### PR TITLE
Add a ko-fi button and release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.4.1 - 2026-08-26
+
+### Added
+- A "Buy me a coffee" button in the preferences footer, next to Report a bug
+  and Request a feature, and a ko-fi link on the extension's page alongside the
+  existing PayPal one.
+
 ## 1.4.0 - 2026-08-26
 
 Thanks to @rafi0x for the multiple-profile support.

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -6,6 +6,7 @@
   "url": "https://github.com/dvdstelt/ClaudeCodeUsage",
   "settings-schema": "org.gnome.shell.extensions.claude-usage",
   "donations": {
+    "kofi": "dvdstelt",
     "paypal": "dvdstelt"
   },
   "version": 12,

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -9,6 +9,6 @@
     "kofi": "dvdstelt",
     "paypal": "dvdstelt"
   },
-  "version": 12,
-  "version-name": "1.4.0"
+  "version": 13,
+  "version-name": "1.4.1"
 }

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -15,6 +15,8 @@ import {
 import {loadProfiles, saveProfiles, makeProfileId, labelForDirName, ensureProfiles} from './lib/profiles.js';
 import {getToken, setToken, clearToken} from './lib/tokenStore.js';
 
+const KOFI_URL = 'https://ko-fi.com/dvdstelt';
+
 // Gtk.FileDialog predates GJS's automatic async/finish pairing for this
 // class on some GNOME versions, so promisify it explicitly.
 Gio._promisify(Gtk.FileDialog.prototype, 'select_folder', 'select_folder_finish');
@@ -429,6 +431,7 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
             margin_bottom: 16,
             halign: Gtk.Align.CENTER,
         });
+        buttons.append(this._buildLinkButton('♥ Buy me a coffee', KOFI_URL));
         buttons.append(this._buildLinkButton('Report a bug', issuesUrl));
         buttons.append(this._buildLinkButton('Request a feature', issuesUrl));
         footer.add(buttons);


### PR DESCRIPTION
Adds a way for people to say thanks, matching the layout Tiling Shell uses.

## Changes

The preferences footer button row becomes:

```
[ ♥ Buy me a coffee ]  [ Report a bug ]  [ Request a feature ]
```

The new button goes through the existing `_buildLinkButton()` helper, so it opens <https://ko-fi.com/dvdstelt> in the default browser exactly like the other two. The URL sits with the other constants at the top of `prefs.js`, and the label uses a literal `♥` to match how the codebase already writes `⚙ Settings` and `↻ Refresh`.

`kofi` is also listed in the `donations` block in `metadata.json`, next to the existing `paypal`, so the same link appears on the extensions.gnome.org page rather than only inside preferences.

## Release

Bumped to **1.4.1 / version code 13** using `./build.sh -patch`, with a matching changelog entry.

## Note on merge order

This depends on #15 landing first. That PR records the panel-placement and shortcut features under **1.4.0**, the version this branch moves past — so merging in the other order would leave `main` claiming 1.4.1 while 1.4.0's features are still unmerged, and #15 would then conflict on both `metadata.json` and the changelog.

Since 1.4.0 has not been uploaded yet, folding this button into 1.4.0 and skipping 1.4.1 entirely is also reasonable — one release instead of two, and no version that only ever existed in git. Happy to rework it that way.